### PR TITLE
fix(editor): fix text wrap problem

### DIFF
--- a/packages/editor/__snapshots__/extensions/extensions/fontBgColor/__tests__/fontBgColor.test.tsx.snap
+++ b/packages/editor/__snapshots__/extensions/extensions/fontBgColor/__tests__/fontBgColor.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`FontBgColor renders FontBgColor correctly 1`] = `
     >
       <p>
         <span
-          style="background-color: [object Object]; display: inline-block"
+          style="background-color: [object Object];"
         >
           red
         </span>

--- a/packages/editor/src/editors/documentEditor/documentEditor.style.ts
+++ b/packages/editor/src/editors/documentEditor/documentEditor.style.ts
@@ -118,9 +118,7 @@ const collaborationStyles: CSS = {
 
 export const selectionStyles: CSS = {
   [`.${DEFAULT_SELECTION_CLASS}`]: {
-    ...defaultSelectionStyles['::selection'],
-    display: 'inline-block',
-    lineHeight: 'inherit'
+    ...defaultSelectionStyles['::selection']
   }
 }
 

--- a/packages/editor/src/extensions/extensions/fontBgColor/fontBgColor.ts
+++ b/packages/editor/src/extensions/extensions/fontBgColor/fontBgColor.ts
@@ -45,7 +45,7 @@ export const FontBgColor = createExtension<FontBgColorOptions, FontBgColorAttrib
               }
 
               return {
-                style: `background-color: ${attributes.fontBgColor}; display: inline-block`
+                style: `background-color: ${attributes.fontBgColor};`
               }
             },
             parseHTML: element => {


### PR DESCRIPTION
make `span` as an `inline-block` to keep `span` as high as the parent element. But it will cause the text-wrap problem.
Since there is no solution, revert the styles.