### PR TITLE
fix(editor): makes selection/bgColor mark as high as its parent element

### DIFF
--- a/packages/design-system/src/themes/common/globalStyle.style.ts
+++ b/packages/design-system/src/themes/common/globalStyle.style.ts
@@ -1,5 +1,4 @@
 import { fontFaceSets } from './fontFaceSets.style'
-import { ceramicLightTheme } from '../ceramic-light/index'
 
 export const globalStyleSheet = {
   ...fontFaceSets,
@@ -64,45 +63,6 @@ export const globalStyleSheet = {
     '&:lang(ja)': {
       fontFamily: '$fonts$jaMonospace'
     }
-  },
-  'h1, h2, h3, h4, h5, h6': {
-    marginTop: 0,
-    marginBottom: 0,
-    fontWeight: '600',
-    color: '$colors$typePrimary',
-    wordBreak: 'break-word'
-  },
-  h1: {
-    fontSize: ceramicLightTheme.fontSizes.title1,
-    lineHeight: ceramicLightTheme.lineHeights.title1,
-    paddingTop: ceramicLightTheme.titleOffset.title1
-  },
-  h2: {
-    fontSize: ceramicLightTheme.fontSizes.title2,
-    lineHeight: ceramicLightTheme.lineHeights.title2,
-    paddingTop: ceramicLightTheme.titleOffset.title2
-  },
-  h3: {
-    fontSize: ceramicLightTheme.fontSizes.title3,
-    lineHeight: ceramicLightTheme.lineHeights.title3,
-    paddingTop: ceramicLightTheme.titleOffset.title3
-  },
-  h4: {
-    fontSize: ceramicLightTheme.fontSizes.title4,
-    lineHeight: ceramicLightTheme.lineHeights.title4,
-    paddingTop: ceramicLightTheme.titleOffset.title4
-  },
-  h5: {
-    fontSize: ceramicLightTheme.fontSizes.title5,
-    lineHeight: ceramicLightTheme.lineHeights.title5,
-    paddingTop: ceramicLightTheme.titleOffset.title5
-  },
-  p: {
-    marginTop: 0,
-    marginBottom: 0,
-    fontSize: ceramicLightTheme.fontSizes.body,
-    lineHeight: ceramicLightTheme.lineHeights.body,
-    wordBreak: 'break-word'
   },
   'input, button, select, optgroup, textarea': {
     margin: 0,

--- a/packages/editor/__snapshots__/editors/documentEditor/__tests__/documentEditor.test.tsx.snap
+++ b/packages/editor/__snapshots__/editors/documentEditor/__tests__/documentEditor.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`documentEditor renders document editor correctly 1`] = `
 <div>
   <div>
     <div
-      class="mc-c-kTveCk mc-c-kTveCk-gHONcO-enableSelection-false"
+      class="mc-c-bUsdRF mc-c-bUsdRF-gHONcO-enableSelection-false"
     >
       <div
         class="ProseMirror"
@@ -12,34 +12,285 @@ exports[`documentEditor renders document editor correctly 1`] = `
         translate="no"
       >
         <div
-          class="react-renderer node-paragraph"
+          class="react-renderer node-heading"
         >
           <div
             data-node-view-wrapper=""
-            style="position: relative; pointer-events: unset; white-space: normal;"
+            style="pointer-events: unset; white-space: normal;"
           >
             <div
               class="mc-c-gNeIVG"
             >
-              <p
-                as="p"
-                class="mc-c-jIptkL mc-c-qcqS"
+              <h1
+                as="h1"
                 data-node-view-content=""
-                data-placeholder=""
-                draggable="false"
-                style="white-space: pre-wrap;"
+                style="--selection-padding: calc((2.875rem - 1.875rem) / 2); --bgColor-padding: calc((2.875rem - 1.875rem) / 2); white-space: pre-wrap;"
               >
                 <div
                   style="white-space: inherit;"
                 >
-                  <br
-                    class="ProseMirror-trailingBreak"
-                  />
+                  heading1
                 </div>
-              </p>
+              </h1>
               <div
                 aria-haspopup="dialog"
-                class="mc-c-iAZzvg"
+                class="mc-c-iAZzvg mc-c-hjKsOe mc-c-hjKsOe-egdRHa-level-1"
+                contenteditable="false"
+                data-drag-handle="true"
+                data-testid="editor-block-action-button"
+                draggable="true"
+              >
+                <button
+                  class="mc-c-iiEeHJ mc-c-iiEeHJ-UZJIs-btnType-text mc-c-iiEeHJ-fcHofs-size-md mc-c-PJLV mc-c-PJLV-klARUB-size-sm ButtonUnstyled-root"
+                  role="button"
+                  type="button"
+                >
+                  <span
+                    aria-label="drag-secondary"
+                    class="mc-icon mc-icon-drag-secondary"
+                    role="img"
+                  >
+                    <svg
+                      fill="none"
+                      height="1em"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-9a9 9 0 1 0 0 18 9 9 0 0 0 0-18Z"
+                        fill="#e0e0e0"
+                        fill-rule="evenodd"
+                      />
+                      <path
+                        clip-rule="evenodd"
+                        d="M7.833 8.5c-.46 0-.833.448-.833 1s.373 1 .833 1h8.334c.46 0 .833-.448.833-1s-.373-1-.833-1H7.833Zm0 5c-.46 0-.833.448-.833 1s.373 1 .833 1h8.334c.46 0 .833-.448.833-1s-.373-1-.833-1H7.833Z"
+                        fill="#35313c"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="react-renderer node-heading"
+        >
+          <div
+            data-node-view-wrapper=""
+            style="pointer-events: unset; white-space: normal;"
+          >
+            <div
+              class="mc-c-gNeIVG"
+            >
+              <h2
+                as="h2"
+                data-node-view-content=""
+                style="--selection-padding: calc((2rem - 1.625rem) / 2); --bgColor-padding: calc((2rem - 1.625rem) / 2); white-space: pre-wrap;"
+              >
+                <div
+                  style="white-space: inherit;"
+                >
+                  heading2
+                </div>
+              </h2>
+              <div
+                aria-haspopup="dialog"
+                class="mc-c-iAZzvg mc-c-hjKsOe mc-c-hjKsOe-iyJHSq-level-2"
+                contenteditable="false"
+                data-drag-handle="true"
+                data-testid="editor-block-action-button"
+                draggable="true"
+              >
+                <button
+                  class="mc-c-iiEeHJ mc-c-iiEeHJ-UZJIs-btnType-text mc-c-iiEeHJ-fcHofs-size-md mc-c-PJLV mc-c-PJLV-klARUB-size-sm ButtonUnstyled-root"
+                  role="button"
+                  type="button"
+                >
+                  <span
+                    aria-label="drag-secondary"
+                    class="mc-icon mc-icon-drag-secondary"
+                    role="img"
+                  >
+                    <svg
+                      fill="none"
+                      height="1em"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-9a9 9 0 1 0 0 18 9 9 0 0 0 0-18Z"
+                        fill="#e0e0e0"
+                        fill-rule="evenodd"
+                      />
+                      <path
+                        clip-rule="evenodd"
+                        d="M7.833 8.5c-.46 0-.833.448-.833 1s.373 1 .833 1h8.334c.46 0 .833-.448.833-1s-.373-1-.833-1H7.833Zm0 5c-.46 0-.833.448-.833 1s.373 1 .833 1h8.334c.46 0 .833-.448.833-1s-.373-1-.833-1H7.833Z"
+                        fill="#35313c"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="react-renderer node-heading"
+        >
+          <div
+            data-node-view-wrapper=""
+            style="pointer-events: unset; white-space: normal;"
+          >
+            <div
+              class="mc-c-gNeIVG"
+            >
+              <h3
+                as="h3"
+                data-node-view-content=""
+                style="--selection-padding: calc((1.875rem - 1.375rem) / 2); --bgColor-padding: calc((1.875rem - 1.375rem) / 2); white-space: pre-wrap;"
+              >
+                <div
+                  style="white-space: inherit;"
+                >
+                  heading3
+                </div>
+              </h3>
+              <div
+                aria-haspopup="dialog"
+                class="mc-c-iAZzvg mc-c-hjKsOe mc-c-hjKsOe-hhWJgB-level-3"
+                contenteditable="false"
+                data-drag-handle="true"
+                data-testid="editor-block-action-button"
+                draggable="true"
+              >
+                <button
+                  class="mc-c-iiEeHJ mc-c-iiEeHJ-UZJIs-btnType-text mc-c-iiEeHJ-fcHofs-size-md mc-c-PJLV mc-c-PJLV-klARUB-size-sm ButtonUnstyled-root"
+                  role="button"
+                  type="button"
+                >
+                  <span
+                    aria-label="drag-secondary"
+                    class="mc-icon mc-icon-drag-secondary"
+                    role="img"
+                  >
+                    <svg
+                      fill="none"
+                      height="1em"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-9a9 9 0 1 0 0 18 9 9 0 0 0 0-18Z"
+                        fill="#e0e0e0"
+                        fill-rule="evenodd"
+                      />
+                      <path
+                        clip-rule="evenodd"
+                        d="M7.833 8.5c-.46 0-.833.448-.833 1s.373 1 .833 1h8.334c.46 0 .833-.448.833-1s-.373-1-.833-1H7.833Zm0 5c-.46 0-.833.448-.833 1s.373 1 .833 1h8.334c.46 0 .833-.448.833-1s-.373-1-.833-1H7.833Z"
+                        fill="#35313c"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="react-renderer node-heading"
+        >
+          <div
+            data-node-view-wrapper=""
+            style="pointer-events: unset; white-space: normal;"
+          >
+            <div
+              class="mc-c-gNeIVG"
+            >
+              <h4
+                as="h4"
+                data-node-view-content=""
+                style="--selection-padding: calc((1.875rem - 1.25rem) / 2); --bgColor-padding: calc((1.875rem - 1.25rem) / 2); white-space: pre-wrap;"
+              >
+                <div
+                  style="white-space: inherit;"
+                >
+                  heading4
+                </div>
+              </h4>
+              <div
+                aria-haspopup="dialog"
+                class="mc-c-iAZzvg mc-c-hjKsOe mc-c-hjKsOe-grfFzG-level-4"
+                contenteditable="false"
+                data-drag-handle="true"
+                data-testid="editor-block-action-button"
+                draggable="true"
+              >
+                <button
+                  class="mc-c-iiEeHJ mc-c-iiEeHJ-UZJIs-btnType-text mc-c-iiEeHJ-fcHofs-size-md mc-c-PJLV mc-c-PJLV-klARUB-size-sm ButtonUnstyled-root"
+                  role="button"
+                  type="button"
+                >
+                  <span
+                    aria-label="drag-secondary"
+                    class="mc-icon mc-icon-drag-secondary"
+                    role="img"
+                  >
+                    <svg
+                      fill="none"
+                      height="1em"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-9a9 9 0 1 0 0 18 9 9 0 0 0 0-18Z"
+                        fill="#e0e0e0"
+                        fill-rule="evenodd"
+                      />
+                      <path
+                        clip-rule="evenodd"
+                        d="M7.833 8.5c-.46 0-.833.448-.833 1s.373 1 .833 1h8.334c.46 0 .833-.448.833-1s-.373-1-.833-1H7.833Zm0 5c-.46 0-.833.448-.833 1s.373 1 .833 1h8.334c.46 0 .833-.448.833-1s-.373-1-.833-1H7.833Z"
+                        fill="#35313c"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="react-renderer node-heading"
+        >
+          <div
+            data-node-view-wrapper=""
+            style="pointer-events: unset; white-space: normal;"
+          >
+            <div
+              class="mc-c-gNeIVG"
+            >
+              <h5
+                as="h5"
+                data-node-view-content=""
+                style="--selection-padding: calc((1.5rem - 1rem) / 2); --bgColor-padding: calc((1.5rem - 1rem) / 2); white-space: pre-wrap;"
+              >
+                <div
+                  style="white-space: inherit;"
+                >
+                  heading5
+                </div>
+              </h5>
+              <div
+                aria-haspopup="dialog"
+                class="mc-c-iAZzvg mc-c-hjKsOe mc-c-hjKsOe-dFWSDb-level-5"
                 contenteditable="false"
                 data-drag-handle="true"
                 data-testid="editor-block-action-button"

--- a/packages/editor/src/components/blockViews/HeadingView/HeadingView.tsx
+++ b/packages/editor/src/components/blockViews/HeadingView/HeadingView.tsx
@@ -43,7 +43,7 @@ const actionButtonStyle = css({
   }
 })
 
-export const HeadingView: FC<HeadingViewProps> = ({ node, deleteNode, getPos }) => {
+export const HeadingView: FC<HeadingViewProps> = ({ node, deleteNode, extension, getPos }) => {
   const as = useMemo(() => {
     switch (Number(node.attrs.level)) {
       case 2:
@@ -53,6 +53,7 @@ export const HeadingView: FC<HeadingViewProps> = ({ node, deleteNode, getPos }) 
       case 4:
         return 'h4'
       case 5:
+      case 6:
         return 'h5'
       case 1:
       default:
@@ -61,6 +62,11 @@ export const HeadingView: FC<HeadingViewProps> = ({ node, deleteNode, getPos }) 
   }, [node.attrs.level])
 
   const actionButtonClassName = actionButtonStyle({ level: node.attrs.level })
+
+  const HTMLAttributes =
+    (typeof extension.options?.HTMLAttributes === 'function'
+      ? extension.options.HTMLAttributes(node.attrs)
+      : extension.options.HTMLAttributes) ?? {}
 
   return (
     <BlockContainer
@@ -71,7 +77,7 @@ export const HeadingView: FC<HeadingViewProps> = ({ node, deleteNode, getPos }) 
       getPos={getPos}
       deleteNode={deleteNode}
       contentForCopy={node.textContent}>
-      <NodeViewContent as={as} />
+      <NodeViewContent {...HTMLAttributes} as={as} />
     </BlockContainer>
   )
 }

--- a/packages/editor/src/components/blockViews/ParagraphView/ParagraphView.tsx
+++ b/packages/editor/src/components/blockViews/ParagraphView/ParagraphView.tsx
@@ -24,7 +24,7 @@ const paragraphStyles = css({
 })
 
 export const ParagraphView: FC<ParagraphViewProps> = props => {
-  const { node, getPos, deleteNode } = props
+  const { node, getPos, deleteNode, extension } = props
   const placeholderClassName = placeholderStyle()
   const paragraphClassName = paragraphStyles()
 
@@ -37,6 +37,7 @@ export const ParagraphView: FC<ParagraphViewProps> = props => {
       style={{ position: 'relative' }}
       actionOptions={['cut', 'copy', 'delete', 'transform']}>
       <NodeViewContent
+        {...extension.options.HTMLAttributes}
         draggable={false}
         data-placeholder=""
         as="p"

--- a/packages/editor/src/editors/documentEditor/__tests__/documentEditor.test.tsx
+++ b/packages/editor/src/editors/documentEditor/__tests__/documentEditor.test.tsx
@@ -27,7 +27,14 @@ describe('documentEditor', () => {
           collaborationCursor: {
             provider
           }
-        }
+        },
+        content: `
+        <h1>heading1</h1>
+        <h2>heading2</h2>
+        <h3>heading3</h3>
+        <h4>heading4</h4>
+        <h5>heading5</h5>
+        `
       })
     )
     const editor = result.current

--- a/packages/editor/src/editors/documentEditor/documentEditor.style.ts
+++ b/packages/editor/src/editors/documentEditor/documentEditor.style.ts
@@ -4,6 +4,66 @@ import { defaultSelectionStyles } from '../../styles/index.style'
 import { DEFAULT_SELECTION_CLASS } from '../../extensions'
 import anchorLine from './assets/anchor-line.png'
 
+export const h1FontSize = theme.fontSizes.title1
+export const h2FontSize = theme.fontSizes.title2
+export const h3FontSize = theme.fontSizes.title3
+export const h4FontSize = theme.fontSizes.title4
+export const h5FontSize = theme.fontSizes.title5
+
+export const h1LienHeight = theme.lineHeights.title1
+export const h2LienHeight = theme.lineHeights.title2
+export const h3LienHeight = theme.lineHeights.title3
+export const h4LienHeight = theme.lineHeights.title4
+export const h5LienHeight = theme.lineHeights.title5
+
+export const paragraphFontSize = theme.fontSizes.body
+export const paragraphLineHeight = theme.lineHeights.body
+
+const headingStyles: CSS = {
+  'h1, h2, h3, h4, h5, h6': {
+    marginTop: 0,
+    marginBottom: 0,
+    fontWeight: '600',
+    color: theme.colors.typePrimary,
+    wordBreak: 'break-word'
+  },
+  h1: {
+    fontSize: h1FontSize,
+    lineHeight: h1LienHeight,
+    paddingTop: theme.titleOffset.title1
+  },
+  h2: {
+    fontSize: h2FontSize,
+    lineHeight: h2LienHeight,
+    paddingTop: theme.titleOffset.title2
+  },
+  h3: {
+    fontSize: h3FontSize,
+    lineHeight: h3LienHeight,
+    paddingTop: theme.titleOffset.title3
+  },
+  h4: {
+    fontSize: h4FontSize,
+    lineHeight: h4LienHeight,
+    paddingTop: theme.titleOffset.title4
+  },
+  h5: {
+    fontSize: h5FontSize,
+    lineHeight: h5LienHeight,
+    paddingTop: theme.titleOffset.title5
+  }
+}
+
+const paragraphStyles: CSS = {
+  p: {
+    marginTop: 0,
+    marginBottom: 0,
+    fontSize: theme.fontSizes.body,
+    lineHeight: theme.lineHeights.body,
+    wordBreak: 'break-word'
+  }
+}
+
 const anchorMarkStyles = {
   'span[data-anchor]': {
     position: 'relative'
@@ -162,6 +222,10 @@ export const documentEditorStyles = css({
       marginTop: '.75rem',
       marginBottom: 0
     },
+
+    ...headingStyles,
+
+    ...paragraphStyles,
 
     ...selectionStyles,
 

--- a/packages/editor/src/editors/documentEditor/documentEditor.tsx
+++ b/packages/editor/src/editors/documentEditor/documentEditor.tsx
@@ -33,7 +33,21 @@ import {
 import { Base, BaseOptions, updateExtensionOptions as updateBaseExtensionOptions } from '../../extensions/base'
 import { useDrawerService } from '../../components/ui/Drawer'
 import { useDropBlock, useUndo } from '../../helpers'
-import { documentEditorStyles } from './documentEditor.style'
+import {
+  documentEditorStyles,
+  h1FontSize,
+  h1LienHeight,
+  h2FontSize,
+  h2LienHeight,
+  h3FontSize,
+  h3LienHeight,
+  h4FontSize,
+  h4LienHeight,
+  h5FontSize,
+  h5LienHeight,
+  paragraphFontSize,
+  paragraphLineHeight
+} from './documentEditor.style'
 import { merge } from 'lodash'
 import { To, NavigateOptions } from 'react-router-dom'
 
@@ -97,6 +111,9 @@ export function useEditor(options: EditorOptions, deps?: DependencyList): Tiptap
   const [t] = useEditorI18n()
   const editorOptions = useMemo<Partial<TiptapEditorOptions>>(() => {
     const { editable, extensions, base, ...restOptions } = options
+    const selectionPaddingVar = '--selection-padding'
+    const backgroundColorPaddingVar = '--bgColor-padding'
+
     return {
       extensions: [
         ...(extensions ?? []),
@@ -122,11 +139,61 @@ export function useEditor(options: EditorOptions, deps?: DependencyList): Tiptap
               embed: true,
               eventHandler: true,
               fontColor: true,
-              fontBgColor: true,
+              fontBgColor: {
+                HTMLAttributes: {
+                  // make bgColor mark as high as parent element
+                  style: `padding: var(${backgroundColorPaddingVar}) 0;`
+                }
+              },
               formula: true,
               gapcursor: false,
               hardBreak: true,
-              heading: true,
+              heading: {
+                HTMLAttributes: attrs => {
+                  // 1. make selection as high as heading
+                  // 2. make bgColor mark as high as heading
+                  switch (attrs.level) {
+                    case 1:
+                      return {
+                        style: {
+                          [selectionPaddingVar]: `calc((${h1LienHeight.value} - ${h1FontSize.value}) / 2)`,
+                          [backgroundColorPaddingVar]: `calc((${h1LienHeight.value} - ${h1FontSize.value}) / 2)`
+                        }
+                      }
+                    case 2:
+                      return {
+                        style: {
+                          [selectionPaddingVar]: `calc((${h2LienHeight.value} - ${h2FontSize.value}) / 2)`,
+                          [backgroundColorPaddingVar]: `calc((${h2LienHeight.value} - ${h2FontSize.value}) / 2)`
+                        }
+                      }
+                    case 3:
+                      return {
+                        style: {
+                          [selectionPaddingVar]: `calc((${h3LienHeight.value} - ${h3FontSize.value}) / 2)`,
+                          [backgroundColorPaddingVar]: `calc((${h3LienHeight.value} - ${h3FontSize.value}) / 2)`
+                        }
+                      }
+                    case 4:
+                      return {
+                        style: {
+                          [selectionPaddingVar]: `calc((${h4LienHeight.value} - ${h4FontSize.value}) / 2)`,
+                          [backgroundColorPaddingVar]: `calc((${h4LienHeight.value} - ${h4FontSize.value}) / 2)`
+                        }
+                      }
+                    case 5:
+                    case 6:
+                      return {
+                        style: {
+                          [selectionPaddingVar]: `calc((${h5LienHeight.value} - ${h5FontSize.value}) / 2)`,
+                          [backgroundColorPaddingVar]: `calc((${h5LienHeight.value} - ${h5FontSize.value}) / 2)`
+                        }
+                      }
+                    default:
+                      return {}
+                  }
+                }
+              },
               history: true,
               horizontalRule: true,
               indent: true,
@@ -139,7 +206,16 @@ export function useEditor(options: EditorOptions, deps?: DependencyList): Tiptap
               mentionCommands: true,
               orderedList: true,
               pageLink: true,
-              paragraph: true,
+              paragraph: {
+                HTMLAttributes: {
+                  style: {
+                    // make selection as high as paragraph
+                    [selectionPaddingVar]: `calc((${paragraphLineHeight} - ${paragraphFontSize}) / 2)`,
+                    // make bgColor mark as high as paragraph
+                    [backgroundColorPaddingVar]: `calc((${paragraphLineHeight} - ${paragraphFontSize}) / 2)`
+                  }
+                }
+              },
               placeholder: {
                 placeholder: ({ wrapperNode }) => {
                   switch (wrapperNode?.type.name) {
@@ -156,7 +232,12 @@ export function useEditor(options: EditorOptions, deps?: DependencyList): Tiptap
                   }
                 }
               },
-              selection: true,
+              selection: {
+                HTMLAttributes: {
+                  // make selection as high as parent element
+                  style: `padding: var(${selectionPaddingVar}) 0`
+                }
+              },
               slashCommands: true,
               spreadsheet: true,
               strike: true,

--- a/packages/editor/src/extensions/blocks/heading/heading.ts
+++ b/packages/editor/src/extensions/blocks/heading/heading.ts
@@ -5,9 +5,12 @@ import { meta } from './meta'
 
 export const Heading = TiptapHeading.extend({
   name: meta.name,
+
   // specify marks for excluding anchor mark
   marks: 'bold italic link strike textStyle discussion',
+
   draggable: true,
+
   addNodeView() {
     return ReactNodeViewRenderer(HeadingView)
   }

--- a/packages/editor/src/extensions/blocks/heading/meta.ts
+++ b/packages/editor/src/extensions/blocks/heading/meta.ts
@@ -1,4 +1,4 @@
-import Heading, { HeadingOptions } from '@tiptap/extension-heading'
+import Heading, { Level } from '@tiptap/extension-heading'
 import { BlockViewProps, ExtensionMeta } from '../../common'
 
 export const meta: ExtensionMeta = {
@@ -6,7 +6,10 @@ export const meta: ExtensionMeta = {
   extensionType: 'block'
 }
 
-export type { HeadingOptions } from '@tiptap/extension-heading'
+export interface HeadingOptions {
+  levels: Level[]
+  HTMLAttributes?: Record<string, any> | ((attrs: HeadingAttributes) => Record<string, any>)
+}
 export interface HeadingAttributes {
   level: 1 | 2 | 3 | 4 | 5 | 6
 }

--- a/packages/editor/src/extensions/blocks/paragraph/meta.ts
+++ b/packages/editor/src/extensions/blocks/paragraph/meta.ts
@@ -1,4 +1,4 @@
-import Paragraph, { ParagraphOptions as TiptapParagraphOptions } from '@tiptap/extension-paragraph'
+import { Paragraph, ParagraphOptions as TiptapParagraphOptions } from '@tiptap/extension-paragraph'
 import { BlockViewProps, ExtensionMeta } from '../../common'
 
 export const meta: ExtensionMeta = {

--- a/packages/editor/src/extensions/extensions/fontBgColor/fontBgColor.ts
+++ b/packages/editor/src/extensions/extensions/fontBgColor/fontBgColor.ts
@@ -4,7 +4,9 @@ import { createExtension } from '../../common'
 import { meta } from './meta'
 
 export interface FontBgColorOptions {
-  types: string[]
+  types?: string[]
+  // TODO: make HTMLAttributes type clear
+  HTMLAttributes?: Record<string, any>
 }
 export interface FontBgColorAttributes {}
 
@@ -45,7 +47,8 @@ export const FontBgColor = createExtension<FontBgColorOptions, FontBgColorAttrib
               }
 
               return {
-                style: `background-color: ${attributes.fontBgColor};`
+                ...this.options.HTMLAttributes,
+                style: `background-color: ${attributes.fontBgColor};${this.options.HTMLAttributes?.style ?? ''}`
               }
             },
             parseHTML: element => {

--- a/packages/editor/src/extensions/extensions/selection/meta.ts
+++ b/packages/editor/src/extensions/extensions/selection/meta.ts
@@ -1,7 +1,7 @@
 import { ExtensionMeta } from '../../common'
 
 export interface SelectionOptions {
-  className?: string
+  HTMLAttributes?: Record<string, string>
 }
 
 export interface SelectAttributes {}

--- a/packages/editor/src/extensions/extensions/selection/selection.ts
+++ b/packages/editor/src/extensions/extensions/selection/selection.ts
@@ -59,12 +59,6 @@ export const DEFAULT_SELECTION_CLASS = 'editor-selection'
 export const Selection = createExtension<SelectionOptions, SelectAttributes>({
   name: meta.name,
 
-  addOptions() {
-    return {
-      className: DEFAULT_SELECTION_CLASS
-    }
-  },
-
   addProseMirrorPlugins() {
     return [
       new Plugin({
@@ -76,7 +70,8 @@ export const Selection = createExtension<SelectionOptions, SelectAttributes>({
             if (!isTextContentSelected({ editor, from, to })) return
 
             const decoration = Decoration.inline(from, to, {
-              class: this.options.className
+              class: this.options.HTMLAttributes?.class ?? DEFAULT_SELECTION_CLASS,
+              style: this.options.HTMLAttributes?.style
             })
 
             decorations.push(decoration)


### PR DESCRIPTION
Because `span` (inline element) can not set CSS property `height/line-height`, `selection/bgColor` mark is not as high as its parent element. Fortunately, `span` accepts  CSS property `padding`.

To make it works:

1. add customize inline style ability to `heading/paragraph/bgColor/selection` extensions (by making `HTMLAttributes` option work).
2. add calculated padding value to CSS variable in `heading/paragraph` inline styles.
3. apply the padding CSS variable in `selection/bgColor` to make its height equal to the parent element.