### PR TITLE
feat(editor): create MultipleNodeSelection

### DIFF
--- a/packages/editor/src/extensions/extensions/selection/MultipleNodeBookmark.ts
+++ b/packages/editor/src/extensions/extensions/selection/MultipleNodeBookmark.ts
@@ -1,0 +1,24 @@
+import { Node } from 'prosemirror-model'
+import { Mappable } from 'prosemirror-transform'
+import { MultipleNodeSelection } from './MultipleNodeSelection'
+
+export class MultipleNodeBookmark {
+  public anchor: number
+  public head: number
+
+  constructor(anchor: number, head: number) {
+    this.anchor = anchor
+    this.head = head
+  }
+
+  map(mapping: Mappable): MultipleNodeBookmark {
+    return new MultipleNodeBookmark(mapping.map(this.anchor), mapping.map(this.head))
+  }
+
+  resolve(doc: Node): MultipleNodeSelection {
+    const $anchorPos = doc.resolve(this.anchor)
+    const $headPos = doc.resolve(this.head)
+
+    return new MultipleNodeSelection($anchorPos, $headPos)
+  }
+}

--- a/packages/editor/src/extensions/extensions/selection/MultipleNodeSelection.ts
+++ b/packages/editor/src/extensions/extensions/selection/MultipleNodeSelection.ts
@@ -1,17 +1,159 @@
-import { Node } from 'prosemirror-model'
-import { Selection } from 'prosemirror-state'
+import { Node, ResolvedPos, Slice, Fragment } from 'prosemirror-model'
+import { Selection, SelectionBookmark, SelectionRange, Transaction } from 'prosemirror-state'
 import { Mappable } from 'prosemirror-transform'
+import { MultipleNodeBookmark } from './MultipleNodeBookmark'
 
+/**
+ * JSON format for Multiple Node Selection
+ */
+interface MultipleNodeJson {
+  /**
+   * type always be 'multiple-node'
+   */
+  type: 'multiple-node'
+  /**
+   * anchor position
+   */
+  anchor: number
+  /**
+   * head position
+   */
+  head: number
+}
+
+/**
+ * A prosemirror selection for multiple nodes selection
+ */
 export class MultipleNodeSelection extends Selection {
+  public $anchorPos: ResolvedPos
+  public $headPos: ResolvedPos
+
+  constructor($anchorPos: ResolvedPos, $headPos: ResolvedPos = $anchorPos) {
+    const doc = $anchorPos.node(0)
+    const ranges: SelectionRange[] = []
+
+    doc.nodesBetween($anchorPos.pos, $headPos.pos, (node, pos) => {
+      ranges.push(new SelectionRange(doc.resolve(pos + 1), doc.resolve(pos + node.nodeSize)))
+      return false
+    })
+
+    super(ranges[0].$from, ranges[0].$to, ranges)
+
+    this.$anchorPos = $anchorPos
+    this.$headPos = $headPos
+  }
+
+  /**
+   * checks if selection is equal to current selection
+   * @param selection to compared Selection
+   * @returns boolean value if input selection equals to current selection
+   */
   eq(selection: Selection): boolean {
-    throw new Error('Method not implemented.')
+    if (!(selection instanceof MultipleNodeSelection)) return false
+    if (this.ranges.length !== selection.ranges.length) return false
+
+    for (let index = 0; index < this.ranges.length; index++) {
+      if (this.ranges[index].$from !== selection.ranges[index].$from) return false
+      if (this.ranges[index].$to !== selection.ranges[index].$to) return false
+    }
+
+    return true
   }
 
-  map(doc: Node, mapping: Mappable): Selection {
-    throw new Error('Method not implemented.')
+  /**
+   * map to a new selection
+   * @param doc Document node
+   * @param mapping  Mappable object
+   * @returns
+   */
+  map(doc: Node, mapping: Mappable): MultipleNodeSelection {
+    const $anchorPos = doc.resolve(mapping.map(this.$anchorPos.pos))
+    const $headPos = doc.resolve(mapping.map(this.$headPos.pos))
+
+    return new MultipleNodeSelection($anchorPos, $headPos)
   }
 
-  toJSON() {
-    throw new Error('Method not implemented.')
+  /**
+   * returns a slice of selected nodes
+   */
+  override content(): Slice {
+    return new Slice(
+      Fragment.from(
+        this.ranges.map(range => {
+          const node = range.$from.node()
+          return node.type.create(node.attrs, node.content)
+        })
+      ),
+      1,
+      1
+    )
+  }
+
+  /**
+   * replace the the content of current selection.
+   * @param tr transaction object
+   * @param content the slice used to replace
+   */
+  override replace(tr: Transaction, content?: Slice | undefined): void {
+    const mapFrom = tr.steps.length
+    for (let i = 0; i < this.ranges.length; i++) {
+      const { $from, $to } = this.ranges[i]
+      const mapping = tr.mapping.slice(mapFrom)
+
+      const replacedContent = i ? Slice.empty : content
+      tr.replace(mapping.map($from.pos), mapping.map($to.pos), replacedContent)
+    }
+    const selection = Selection.findFrom(tr.doc.resolve(tr.mapping.slice(mapFrom).map(this.to)), -1)
+    if (selection) tr.setSelection(selection)
+  }
+
+  /**
+   * replace the the content of current selection by specified node.
+   * @param tr transaction object.
+   * @param node  the node used to replace
+   */
+  override replaceWith(tr: Transaction, node: Node): void {
+    this.replace(tr, new Slice(Fragment.from(node), 0, 0))
+  }
+
+  override getBookmark(): SelectionBookmark {
+    return new MultipleNodeBookmark(this.$anchorPos.pos, this.$headPos.pos)
+  }
+
+  /**
+   * converts MultipleNodeSelection to JSON object
+   * @returns
+   */
+  toJSON(): MultipleNodeJson {
+    return {
+      type: 'multiple-node',
+      anchor: this.$anchorPos.pos,
+      head: this.$headPos.pos
+    }
+  }
+
+  /**
+   * converts JSON object to MultipleNodeSelection
+   * @param doc Document node
+   * @param json
+   * @returns
+   */
+  static override fromJSON(doc: Node, json: MultipleNodeJson): MultipleNodeSelection {
+    return new MultipleNodeSelection(doc.resolve(json.anchor), doc.resolve(json.head))
+  }
+
+  /**
+   * creates a new MultipleNodeSelection
+   * @param doc Document node
+   * @param anchor anchor position
+   * @param head head position
+   * @returns
+   */
+  static create(doc: Node, anchor: number, head: number = anchor): MultipleNodeSelection {
+    return new MultipleNodeSelection(doc.resolve(anchor), doc.resolve(head))
   }
 }
+
+MultipleNodeSelection.prototype.visible = false
+
+Selection.jsonID('multipleNode', MultipleNodeSelection)

--- a/packages/editor/src/extensions/extensions/selection/__tests__/MultipleNodeSelection.test.ts
+++ b/packages/editor/src/extensions/extensions/selection/__tests__/MultipleNodeSelection.test.ts
@@ -1,0 +1,204 @@
+import { TextSelection } from 'prosemirror-state'
+import { Mappable } from 'prosemirror-transform'
+import { renderHook } from '@testing-library/react'
+import { useTestEditor } from '../../../../test'
+import { MultipleNodeSelection } from '../MultipleNodeSelection'
+import { MultipleNodeBookmark } from '../MultipleNodeBookmark'
+
+describe('MultipleNodeSelection', () => {
+  it('creates MultipleNodeSelection includes multiple nodes correctly', () => {
+    const anchor = 1
+    const head = 4
+    const text1 = '1'
+    const text2 = '2'
+    const { result } = renderHook(() =>
+      useTestEditor({
+        content: `
+          <p>${text1}</p>
+          <p>${text2}</p>
+        `
+      })
+    )
+
+    const editor = result.current!
+
+    const selection = MultipleNodeSelection.create(editor.state.doc, anchor, head)
+
+    expect(selection.$anchorPos.pos).toEqual(anchor)
+    expect(selection.$headPos.pos).toEqual(head)
+    expect(selection.ranges.length).toBe(2)
+    expect(selection.$anchorPos.node().textContent).toEqual(text1)
+    expect(selection.$headPos.node().textContent).toEqual(text2)
+  })
+
+  it('equals to another selection included same nodes', () => {
+    const { result } = renderHook(() =>
+      useTestEditor({
+        content: `
+          <p>1</p>
+          <p>2</p>
+          <p>3</p>
+        `
+      })
+    )
+
+    const editor = result.current!
+
+    const selection1 = MultipleNodeSelection.create(editor.state.doc, 1, 4)
+    const selection2 = MultipleNodeSelection.create(editor.state.doc, 1, 5)
+    const selection3 = MultipleNodeSelection.create(editor.state.doc, 1, 2)
+    const selection4 = MultipleNodeSelection.create(editor.state.doc, 4, 7)
+    const selection5 = TextSelection.create(editor.state.doc, 1, 4)
+
+    expect(selection1.eq(selection2)).toBeTruthy()
+    expect(selection1.eq(selection3)).toBeFalsy()
+    expect(selection1.eq(selection4)).toBeFalsy()
+    expect(selection1.eq(selection5)).toBeFalsy()
+  })
+
+  it('transforms to JSON object correctly', () => {
+    const anchor = 1
+    const head = 4
+    const { result } = renderHook(() =>
+      useTestEditor({
+        content: `
+          <p>1</p>
+          <p>2</p>
+        `
+      })
+    )
+
+    const editor = result.current!
+
+    const selection = MultipleNodeSelection.create(editor.state.doc, anchor, head)
+
+    expect(selection.toJSON()).toMatchObject({
+      type: 'multiple-node',
+      anchor,
+      head
+    })
+  })
+
+  it('transforms from JSON object correctly', () => {
+    const anchor = 1
+    const head = 4
+    const { result } = renderHook(() =>
+      useTestEditor({
+        content: `
+          <p>1</p>
+          <p>2</p>
+        `
+      })
+    )
+
+    const editor = result.current!
+
+    const selection = MultipleNodeSelection.fromJSON(editor.state.doc, {
+      type: 'multiple-node',
+      anchor,
+      head
+    })
+
+    expect(selection.$anchorPos.pos).toEqual(anchor)
+    expect(selection.$headPos.pos).toEqual(head)
+  })
+
+  it('maps to new selection correctly', () => {
+    const anchor = 1
+    const head = 4
+    const { result } = renderHook(() =>
+      useTestEditor({
+        content: `
+          <p>1</p>
+          <p>2</p>
+        `
+      })
+    )
+
+    const editor = result.current!
+
+    const selection = MultipleNodeSelection.create(editor.state.doc, anchor, head)
+
+    const mapping: Mappable = {
+      map(pos) {
+        return pos + 1
+      },
+      mapResult(pos: number, assoc?: number | undefined) {
+        throw new Error('mapResult not implemented.')
+      }
+    }
+
+    const newSelection = selection.map(editor.state.doc, mapping)
+
+    expect(newSelection.$anchorPos.pos).toEqual(anchor + 1)
+    expect(newSelection.$headPos.pos).toEqual(head + 1)
+  })
+
+  it('gets a slice of selected contents correctly', () => {
+    const anchor = 1
+    const head = 4
+    const text1 = '1'
+    const text2 = '2'
+    const { result } = renderHook(() =>
+      useTestEditor({
+        content: `
+          <p>${text1}</p>
+          <p>${text2}</p>
+        `
+      })
+    )
+
+    const editor = result.current!
+
+    const selection = MultipleNodeSelection.create(editor.state.doc, anchor, head)
+
+    expect(selection.content().content.childCount).toBe(2)
+    expect(selection.content().content.firstChild?.textContent).toEqual(text1)
+    expect(selection.content().content.lastChild?.textContent).toEqual(text2)
+  })
+
+  it('replaces selection by node correctly', () => {
+    const anchor = 1
+    const head = 4
+    const text1 = '1'
+    const text2 = '2'
+    const { result } = renderHook(() =>
+      useTestEditor({
+        content: `
+          <p>${text1}</p>
+          <p>${text2}</p>
+        `
+      })
+    )
+
+    const editor = result.current!
+
+    const selection = MultipleNodeSelection.create(editor.state.doc, anchor, head)
+    const node = selection.ranges[0].$from.node()
+    editor.commands.command(({ tr }) => {
+      selection.replaceWith(tr, node)
+      return true
+    })
+
+    expect(editor.state.doc.textContent).toBe(text1)
+  })
+
+  it('gets bookmark correctly', () => {
+    const anchor = 1
+    const head = 4
+    const { result } = renderHook(() =>
+      useTestEditor({
+        content: `
+          <p>1</p>
+          <p>2</p>
+        `
+      })
+    )
+
+    const editor = result.current!
+
+    const selection = MultipleNodeSelection.create(editor.state.doc, anchor, head)
+
+    expect(selection.getBookmark()).toBeInstanceOf(MultipleNodeBookmark)
+  })
+})


### PR DESCRIPTION
Introduce new selection: `MultipleNodeSelection` for selecting multiple nodes.

TextSelection can include multiple nodes, but it treats nodes as text. `MultipleNodeSelection` will always focus on node selection and exclude text segments.