### PR TITLE
Feat multiple node selection

### DIFF
--- a/apps/client-web/src/docs/pages/DocumentPage.tsx
+++ b/apps/client-web/src/docs/pages/DocumentPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import { FC, MouseEventHandler, useCallback, useEffect, useMemo, useState } from 'react'
 import { Spin } from '@mashcard/design-system'
 import { EditorContent, useEditor } from '@mashcard/editor'
 import { DocumentTitle } from './components/DocumentTitle'
@@ -18,7 +18,7 @@ interface DocumentPageProps {
   mode?: 'default' | 'presentation'
 }
 
-export const DocumentPage: React.FC<DocumentPageProps> = ({ mode }) => {
+export const DocumentPage: FC<DocumentPageProps> = ({ mode }) => {
   const docMeta = useDocMeta()
   const navigate = useNavigate()
   const [latestLoading, setLatestLoading] = useState(true)
@@ -65,8 +65,16 @@ export const DocumentPage: React.FC<DocumentPageProps> = ({ mode }) => {
   }, [editor, freeze])
 
   useEffect(() => {
-  if (!loading) setLatestLoading(false)
-} , [loading, setLatestLoading])
+    if (!loading) setLatestLoading(false)
+  }, [loading, setLatestLoading])
+
+  // setup this mouse down handler to start node selection when click outside the document area
+  const handleMouseDown = useCallback<MouseEventHandler<HTMLDivElement>>(
+    event => {
+      editor?.commands.startMultipleNodeSelection(event.nativeEvent)
+    },
+    [editor?.commands]
+  )
 
   if (latestLoading || !currentRootBlock) {
     return (
@@ -84,7 +92,7 @@ export const DocumentPage: React.FC<DocumentPageProps> = ({ mode }) => {
           '@mdOnly': 'md',
           '@smDown': 'sm'
         }}
-      >
+        onMouseDown={handleMouseDown}>
         <DocumentTitle docBlock={currentRootBlock} editable={documentEditable} meta={meta} setMeta={setMeta} />
         <Root.PageContent>
           <EditorContent

--- a/packages/editor/__snapshots__/editors/documentEditor/__tests__/documentEditor.test.tsx.snap
+++ b/packages/editor/__snapshots__/editors/documentEditor/__tests__/documentEditor.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`documentEditor renders document editor correctly 1`] = `
 <div>
   <div>
     <div
-      class="mc-c-kFryAW mc-c-kFryAW-gHONcO-enableSelection-false"
+      class="mc-c-liApjz mc-c-liApjz-gHONcO-enableSelection-false"
     >
       <div
         class="ProseMirror"

--- a/packages/editor/src/components/blockViews/ParagraphView/ParagraphView.tsx
+++ b/packages/editor/src/components/blockViews/ParagraphView/ParagraphView.tsx
@@ -28,8 +28,6 @@ export const ParagraphView: FC<ParagraphViewProps> = props => {
   const placeholderClassName = placeholderStyle()
   const paragraphClassName = paragraphStyles()
 
-  console.log(props)
-
   return (
     <BlockContainer
       node={node}

--- a/packages/editor/src/components/blockViews/ParagraphView/ParagraphView.tsx
+++ b/packages/editor/src/components/blockViews/ParagraphView/ParagraphView.tsx
@@ -28,6 +28,8 @@ export const ParagraphView: FC<ParagraphViewProps> = props => {
   const placeholderClassName = placeholderStyle()
   const paragraphClassName = paragraphStyles()
 
+  console.log(props)
+
   return (
     <BlockContainer
       node={node}

--- a/packages/editor/src/editors/documentEditor/documentEditor.style.ts
+++ b/packages/editor/src/editors/documentEditor/documentEditor.style.ts
@@ -1,4 +1,4 @@
-import { css, CSS, theme } from '@mashcard/design-system'
+import { css, CSS, globalCss, theme } from '@mashcard/design-system'
 import { spreadsheetStyles } from '../../components/blockViews/Spreadsheet/Spreadsheet.style'
 import { defaultSelectionStyles } from '../../styles/index.style'
 import anchorLine from './assets/anchor-line.png'
@@ -177,6 +177,7 @@ const collaborationStyles: CSS = {
 
 export const textSelectionClassName = 'text-selection-highlight'
 export const nodeSelectionClassName = 'node-selection-highlight'
+export const nodeSelectionMouseAreaClassName = 'node-selection-mouse-area-highlight'
 
 export const selectionStyles: CSS = {
   [`.${nodeSelectionClassName}`]: {
@@ -186,6 +187,12 @@ export const selectionStyles: CSS = {
     ...defaultSelectionStyles['::selection']
   }
 }
+
+export const globalStyles = globalCss({
+  [`.${nodeSelectionMouseAreaClassName}`]: {
+    ...defaultSelectionStyles['::selection']
+  }
+})
 
 export const documentEditorStyles = css({
   variants: {

--- a/packages/editor/src/editors/documentEditor/documentEditor.style.ts
+++ b/packages/editor/src/editors/documentEditor/documentEditor.style.ts
@@ -177,7 +177,7 @@ const collaborationStyles: CSS = {
 
 export const textSelectionClassName = 'text-selection-highlight'
 export const nodeSelectionClassName = 'node-selection-highlight'
-export const nodeSelectionMouseAreaClassName = 'node-selection-mouse-area-highlight'
+export const nodeSelectionMouseSelectionClassName = 'node-selection-mouse-selection-highlight'
 
 export const selectionStyles: CSS = {
   [`.${nodeSelectionClassName}`]: {
@@ -189,7 +189,7 @@ export const selectionStyles: CSS = {
 }
 
 export const globalStyles = globalCss({
-  [`.${nodeSelectionMouseAreaClassName}`]: {
+  [`.${nodeSelectionMouseSelectionClassName}`]: {
     ...defaultSelectionStyles['::selection']
   }
 })

--- a/packages/editor/src/editors/documentEditor/documentEditor.style.ts
+++ b/packages/editor/src/editors/documentEditor/documentEditor.style.ts
@@ -1,7 +1,6 @@
 import { css, CSS, theme } from '@mashcard/design-system'
 import { spreadsheetStyles } from '../../components/blockViews/Spreadsheet/Spreadsheet.style'
 import { defaultSelectionStyles } from '../../styles/index.style'
-import { DEFAULT_SELECTION_CLASS } from '../../extensions'
 import anchorLine from './assets/anchor-line.png'
 
 export const h1FontSize = theme.fontSizes.title1
@@ -176,8 +175,14 @@ const collaborationStyles: CSS = {
   }
 }
 
+export const textSelectionClassName = 'text-selection-highlight'
+export const nodeSelectionClassName = 'node-selection-highlight'
+
 export const selectionStyles: CSS = {
-  [`.${DEFAULT_SELECTION_CLASS}`]: {
+  [`.${nodeSelectionClassName}`]: {
+    ...defaultSelectionStyles['::selection']
+  },
+  [`.${textSelectionClassName}`]: {
     ...defaultSelectionStyles['::selection']
   }
 }

--- a/packages/editor/src/editors/documentEditor/documentEditor.tsx
+++ b/packages/editor/src/editors/documentEditor/documentEditor.tsx
@@ -35,6 +35,7 @@ import { useDrawerService } from '../../components/ui/Drawer'
 import { useUndo } from '../../helpers'
 import {
   documentEditorStyles,
+  globalStyles,
   h1FontSize,
   h1LienHeight,
   h2FontSize,
@@ -46,6 +47,7 @@ import {
   h5FontSize,
   h5LienHeight,
   nodeSelectionClassName,
+  nodeSelectionMouseAreaClassName,
   paragraphFontSize,
   paragraphLineHeight,
   textSelectionClassName
@@ -64,6 +66,7 @@ export interface EditorContentProps {
 }
 
 export const EditorContent: FC<EditorContentProps> = ({ editor, editable, rootId, ...props }) => {
+  globalStyles()
   const editorContext = useMemo<EditorContextData>(() => ({ editor, documentEditable: editable }), [editable, editor])
   const documentContext = useMemo<DocumentContextData>(() => ({ docId: rootId }), [rootId])
   useDrawerService()
@@ -237,6 +240,9 @@ export function useEditor(options: EditorOptions, deps?: DependencyList): Tiptap
               },
               selection: {
                 nodeSelection: {
+                  mouseArea: {
+                    className: nodeSelectionMouseAreaClassName
+                  },
                   className: nodeSelectionClassName
                 },
                 textSelection: {

--- a/packages/editor/src/editors/documentEditor/documentEditor.tsx
+++ b/packages/editor/src/editors/documentEditor/documentEditor.tsx
@@ -47,7 +47,7 @@ import {
   h5FontSize,
   h5LienHeight,
   nodeSelectionClassName,
-  nodeSelectionMouseAreaClassName,
+  nodeSelectionMouseSelectionClassName,
   paragraphFontSize,
   paragraphLineHeight,
   textSelectionClassName
@@ -240,8 +240,8 @@ export function useEditor(options: EditorOptions, deps?: DependencyList): Tiptap
               },
               selection: {
                 nodeSelection: {
-                  mouseArea: {
-                    className: nodeSelectionMouseAreaClassName
+                  mouseSelection: {
+                    className: nodeSelectionMouseSelectionClassName
                   },
                   className: nodeSelectionClassName
                 },

--- a/packages/editor/src/editors/documentEditor/documentEditor.tsx
+++ b/packages/editor/src/editors/documentEditor/documentEditor.tsx
@@ -45,8 +45,10 @@ import {
   h4LienHeight,
   h5FontSize,
   h5LienHeight,
+  nodeSelectionClassName,
   paragraphFontSize,
-  paragraphLineHeight
+  paragraphLineHeight,
+  textSelectionClassName
 } from './documentEditor.style'
 import { merge } from 'lodash'
 import { To, NavigateOptions } from 'react-router-dom'
@@ -234,7 +236,11 @@ export function useEditor(options: EditorOptions, deps?: DependencyList): Tiptap
                 }
               },
               selection: {
-                HTMLAttributes: {
+                nodeSelection: {
+                  className: nodeSelectionClassName
+                },
+                textSelection: {
+                  className: textSelectionClassName,
                   // make selection as high as parent element
                   style: `padding: var(${selectionPaddingVar}) 0`
                 }

--- a/packages/editor/src/extensions/extensions/bubbleMenu/bubbleMenuViewPlugin.ts
+++ b/packages/editor/src/extensions/extensions/bubbleMenu/bubbleMenuViewPlugin.ts
@@ -1,6 +1,6 @@
 // https://github.com/ueberdosis/tiptap/tree/main/packages/extension-bubble-menu
 import { Editor, posToDOMRect } from '@tiptap/core'
-import { EditorState, Plugin, PluginKey, Selection } from 'prosemirror-state'
+import { EditorState, Plugin, PluginKey, Selection, TextSelection } from 'prosemirror-state'
 import { EditorView } from 'prosemirror-view'
 import tippy, { Instance, Props } from 'tippy.js'
 
@@ -118,6 +118,7 @@ export class BubbleMenuView {
   }
 
   createBubbleMenuPopover(view: EditorView, selection: Selection): void {
+    if (!(selection instanceof TextSelection)) return
     this.createTooltip()
 
     // support for CellSelections

--- a/packages/editor/src/extensions/extensions/eventHandler/gapClickHandler.ts
+++ b/packages/editor/src/extensions/extensions/eventHandler/gapClickHandler.ts
@@ -15,9 +15,8 @@ export const gapClickHandler = (editor: Editor, view: EditorView, position: numb
     return
   }
 
-  if (position - 1 < 0) return
-
   // when clicked at the end of document, the latest two position will be null
+  if (position - 2 < 0) return
   const node = view.state.doc.nodeAt(position - 2)
   const nextNode = view.state.doc.nodeAt(position)
 

--- a/packages/editor/src/extensions/extensions/selection/MultipleNodeSelection.ts
+++ b/packages/editor/src/extensions/extensions/selection/MultipleNodeSelection.ts
@@ -35,6 +35,14 @@ export class MultipleNodeSelection extends Selection {
     const from = Math.min($anchorPos.pos, $headPos.pos)
     const to = Math.max($anchorPos.pos, $headPos.pos)
 
+    if (from === to) {
+      const node = doc.nodeAt(from)
+
+      if (node) {
+        ranges.push(new SelectionRange(doc.resolve(from), doc.resolve(from + node.nodeSize)))
+      }
+    }
+
     doc.nodesBetween(from, to, (node, pos) => {
       ranges.push(new SelectionRange(doc.resolve(pos), doc.resolve(pos + node.nodeSize)))
       return false

--- a/packages/editor/src/extensions/extensions/selection/MultipleNodeSelection.ts
+++ b/packages/editor/src/extensions/extensions/selection/MultipleNodeSelection.ts
@@ -41,12 +41,12 @@ export class MultipleNodeSelection extends Selection {
       if (node) {
         ranges.push(new SelectionRange(doc.resolve(from), doc.resolve(from + node.nodeSize)))
       }
+    } else {
+      doc.nodesBetween(from, to + 1, (node, pos) => {
+        ranges.push(new SelectionRange(doc.resolve(pos), doc.resolve(pos + node.nodeSize)))
+        return false
+      })
     }
-
-    doc.nodesBetween(from, to + 1, (node, pos) => {
-      ranges.push(new SelectionRange(doc.resolve(pos), doc.resolve(pos + node.nodeSize)))
-      return false
-    })
 
     super(ranges[0]?.$from ?? $anchorPos, ranges[0]?.$to ?? $headPos, ranges)
 

--- a/packages/editor/src/extensions/extensions/selection/MultipleNodeSelection.ts
+++ b/packages/editor/src/extensions/extensions/selection/MultipleNodeSelection.ts
@@ -32,8 +32,11 @@ export class MultipleNodeSelection extends Selection {
     const doc = $anchorPos.node(0)
     const ranges: SelectionRange[] = []
 
-    doc.nodesBetween($anchorPos.pos, $headPos.pos, (node, pos) => {
-      ranges.push(new SelectionRange(doc.resolve(pos + 1), doc.resolve(pos + node.nodeSize)))
+    const from = Math.min($anchorPos.pos, $headPos.pos)
+    const to = Math.max($anchorPos.pos, $headPos.pos)
+
+    doc.nodesBetween(from, to, (node, pos) => {
+      ranges.push(new SelectionRange(doc.resolve(pos), doc.resolve(pos + node.nodeSize)))
       return false
     })
 
@@ -150,6 +153,7 @@ export class MultipleNodeSelection extends Selection {
    * @returns
    */
   static create(doc: Node, anchor: number, head: number = anchor): MultipleNodeSelection {
+    console.log(anchor, head)
     return new MultipleNodeSelection(doc.resolve(anchor), doc.resolve(head))
   }
 }

--- a/packages/editor/src/extensions/extensions/selection/MultipleNodeSelection.ts
+++ b/packages/editor/src/extensions/extensions/selection/MultipleNodeSelection.ts
@@ -80,16 +80,7 @@ export class MultipleNodeSelection extends Selection {
    * returns a slice of selected nodes
    */
   override content(): Slice {
-    return new Slice(
-      Fragment.from(
-        this.ranges.map(range => {
-          const node = range.$from.node()
-          return node.type.create(node.attrs, node.content)
-        })
-      ),
-      1,
-      1
-    )
+    return new Slice(Fragment.from(this.ranges.map(range => range.$from.nodeAfter!).filter(node => !!node)), 1, 1)
   }
 
   /**
@@ -153,7 +144,6 @@ export class MultipleNodeSelection extends Selection {
    * @returns
    */
   static create(doc: Node, anchor: number, head: number = anchor): MultipleNodeSelection {
-    console.log(anchor, head)
     return new MultipleNodeSelection(doc.resolve(anchor), doc.resolve(head))
   }
 }

--- a/packages/editor/src/extensions/extensions/selection/MultipleNodeSelection.ts
+++ b/packages/editor/src/extensions/extensions/selection/MultipleNodeSelection.ts
@@ -43,12 +43,12 @@ export class MultipleNodeSelection extends Selection {
       }
     }
 
-    doc.nodesBetween(from, to, (node, pos) => {
+    doc.nodesBetween(from, to + 1, (node, pos) => {
       ranges.push(new SelectionRange(doc.resolve(pos), doc.resolve(pos + node.nodeSize)))
       return false
     })
 
-    super(ranges[0].$from, ranges[0].$to, ranges)
+    super(ranges[0]?.$from ?? $anchorPos, ranges[0]?.$to ?? $headPos, ranges)
 
     this.$anchorPos = $anchorPos
     this.$headPos = $headPos

--- a/packages/editor/src/extensions/extensions/selection/__tests__/MultipleNodeSelection.test.ts
+++ b/packages/editor/src/extensions/extensions/selection/__tests__/MultipleNodeSelection.test.ts
@@ -6,6 +6,27 @@ import { MultipleNodeSelection } from '../MultipleNodeSelection'
 import { MultipleNodeBookmark } from '../MultipleNodeBookmark'
 
 describe('MultipleNodeSelection', () => {
+  it('creates MultipleNodeSelection includes one node correctly', () => {
+    const anchor = 1
+    const head = 1
+    const text1 = '1'
+    const { result } = renderHook(() =>
+      useTestEditor({
+        content: `
+          <p>${text1}</p>
+        `
+      })
+    )
+
+    const editor = result.current!
+
+    const selection = MultipleNodeSelection.create(editor.state.doc, anchor, head)
+
+    expect(selection.$anchorPos.pos).toEqual(anchor)
+    expect(selection.$headPos.pos).toEqual(head)
+    expect(selection.ranges.length).toBe(1)
+    expect(selection.$anchorPos.node().textContent).toEqual(text1)
+  })
   it('creates MultipleNodeSelection includes multiple nodes correctly', () => {
     const anchor = 1
     const head = 4
@@ -174,7 +195,7 @@ describe('MultipleNodeSelection', () => {
     const editor = result.current!
 
     const selection = MultipleNodeSelection.create(editor.state.doc, anchor, head)
-    const node = selection.ranges[0].$from.node()
+    const node = editor.state.doc.nodeAt(selection.ranges[0].$from.pos)!
     editor.commands.command(({ tr }) => {
       selection.replaceWith(tr, node)
       return true

--- a/packages/editor/src/extensions/extensions/selection/__tests__/decorations.test.ts
+++ b/packages/editor/src/extensions/extensions/selection/__tests__/decorations.test.ts
@@ -1,0 +1,165 @@
+import { renderHook } from '@testing-library/react-hooks'
+import { mockEditor, useTestEditor } from '../../../../test'
+import { nodeSelectionDecoration, textSelectionDecoration } from '../decorations'
+import { Selection } from '../selection'
+
+describe('Selection Decorations', () => {
+  describe('TextSelection', () => {
+    it('creates null if editor is not editable correctly', () => {
+      const editor = mockEditor({
+        isEditable: false
+      })
+
+      const decorationSet = textSelectionDecoration(
+        editor,
+        {
+          textSelection: {},
+          nodeSelection: {}
+        },
+        editor.state
+      )
+
+      expect(decorationSet).toBeNull()
+    })
+
+    it('creates null if selection is empty correctly', () => {
+      const editor = mockEditor({
+        isEditable: true,
+        state: {
+          selection: {
+            empty: true
+          }
+        }
+      })
+
+      const decorationSet = textSelectionDecoration(
+        editor,
+        {
+          textSelection: {},
+          nodeSelection: {}
+        },
+        editor.state
+      )
+
+      expect(decorationSet).toBeNull()
+    })
+
+    it('creates null if selection is not a TextSelection correctly', () => {
+      const editor = mockEditor({
+        isEditable: true,
+        state: {
+          selection: {
+            from: 1,
+            to: 2
+          }
+        }
+      })
+
+      const decorationSet = textSelectionDecoration(
+        editor,
+        {
+          textSelection: {},
+          nodeSelection: {}
+        },
+        editor.state
+      )
+
+      expect(decorationSet).toBeNull()
+    })
+
+    it('creates text selection decoration correctly', () => {
+      const from = 1
+      const to = 2
+
+      // eslint-disable-next-line max-nested-callbacks
+      const { result } = renderHook(() =>
+        useTestEditor({
+          content: '<p>12</p>'
+        })
+      )
+      const editor = result.current!
+
+      editor.commands.setTextSelection({ from, to })
+
+      const decorationSet = textSelectionDecoration(
+        editor,
+        {
+          textSelection: {},
+          nodeSelection: {}
+        },
+        editor.state
+      )
+
+      expect(decorationSet?.find(from, to)).toHaveLength(1)
+    })
+  })
+
+  describe('MultipleNodeSelection', () => {
+    it('creates null if editor is not editable correctly', () => {
+      const editor = mockEditor({
+        isEditable: false
+      })
+
+      const decorationSet = nodeSelectionDecoration(
+        editor,
+        {
+          textSelection: {},
+          nodeSelection: {}
+        },
+        editor.state
+      )
+
+      expect(decorationSet).toBeNull()
+    })
+
+    it('creates null if selection is not a MultipleNodeSelection correctly', () => {
+      const editor = mockEditor({
+        isEditable: true,
+        state: {
+          selection: {
+            from: 1,
+            to: 2
+          }
+        }
+      })
+
+      const decorationSet = nodeSelectionDecoration(
+        editor,
+        {
+          textSelection: {},
+          nodeSelection: {}
+        },
+        editor.state
+      )
+
+      expect(decorationSet).toBeNull()
+    })
+
+    it('creates node selection decoration correctly', () => {
+      const from = 1
+      const to = 2
+
+      // eslint-disable-next-line max-nested-callbacks
+      const { result } = renderHook(() =>
+        useTestEditor({
+          content: '<p>12</p>',
+          extensions: [Selection]
+        })
+      )
+      const editor = result.current!
+
+      editor.commands.setMultipleNodeSelection(from, to)
+
+      const decorationSet = nodeSelectionDecoration(
+        editor,
+        {
+          textSelection: {},
+          nodeSelection: {}
+        },
+        editor.state
+      )
+
+      expect(decorationSet?.find(from, to)).toHaveLength(1)
+    })
+  })
+})

--- a/packages/editor/src/extensions/extensions/selection/__tests__/domEvents.test.ts
+++ b/packages/editor/src/extensions/extensions/selection/__tests__/domEvents.test.ts
@@ -1,0 +1,205 @@
+import { mockEditor } from '../../../../test'
+import { MultipleNodeSelectionDomEvents } from '../domEvents'
+import { SelectionPluginKey } from '../selection'
+
+jest.useFakeTimers()
+
+describe('DomEvents', () => {
+  it('calls mousedown correctly', () => {
+    const mockSetMeta = jest.fn()
+    const x = 1
+    const y = 1
+    const editor = mockEditor({
+      view: {
+        posAtCoords: () => ({
+          inside: -1
+        }),
+        state: {
+          tr: {
+            setMeta: mockSetMeta
+          }
+        }
+      }
+    })
+    const domEvents = new MultipleNodeSelectionDomEvents(editor, {})
+
+    const event: Partial<MouseEvent> = {
+      clientX: x,
+      clientY: y
+    }
+
+    expect(domEvents.mousedown(editor.view, event as MouseEvent)).toBeFalsy()
+    expect(mockSetMeta).toBeCalledWith('updateSelectionAnchor', {
+      x,
+      y
+    })
+  })
+
+  it('calls mousemove correctly', () => {
+    const mockSetMeta = jest.fn()
+    const x = 1
+    const y = 1
+    const dom = document.createElement('div')
+
+    // @ts-expect-error
+    const editor = mockEditor({
+      view: {
+        dom,
+        posAtCoords: () => ({
+          inside: -1
+        }),
+        state: {
+          [(SelectionPluginKey as any).key]: {
+            multiNodeSelecting: {
+              selecting: false,
+              anchor: {
+                x,
+                y
+              }
+            }
+          },
+          tr: {
+            setMeta: mockSetMeta
+          }
+        }
+      }
+    })
+    const domEvents = new MultipleNodeSelectionDomEvents(editor, {})
+
+    const event: Partial<MouseEvent> = {
+      clientX: x,
+      clientY: y
+    }
+
+    expect(domEvents.mousemove(editor.view, event as MouseEvent)).toBeFalsy()
+    expect(mockSetMeta).toBeCalledTimes(2)
+  })
+
+  it('calls mouseup correctly', () => {
+    const mockSetMeta = jest.fn()
+    const x = 1
+    const y = 1
+    const dom = document.createElement('div')
+    const editor = mockEditor({
+      view: {
+        dom,
+        posAtCoords: () => ({
+          inside: -1
+        }),
+        state: {
+          [(SelectionPluginKey as any).key]: {
+            multiNodeSelecting: {
+              selecting: false,
+              anchor: {
+                x,
+                y
+              }
+            }
+          },
+          tr: {
+            setMeta: mockSetMeta
+          }
+        }
+      }
+    })
+    const domEvents = new MultipleNodeSelectionDomEvents(editor, {})
+
+    const event: Partial<MouseEvent> = {
+      clientX: x,
+      clientY: y
+    }
+
+    expect(domEvents.mouseup(editor.view, event as MouseEvent)).toBeFalsy()
+    jest.runAllTimers()
+    expect(mockSetMeta).toBeCalledWith('multipleNodeSelectingEnd', true)
+  })
+
+  it('calls dragstart correctly', () => {
+    const mockSetMeta = jest.fn()
+    const x = 1
+    const y = 1
+    const dom = document.createElement('div')
+    const editor = mockEditor({
+      view: {
+        dom,
+        posAtCoords: () => ({
+          inside: -1
+        }),
+        state: {
+          [(SelectionPluginKey as any).key]: {
+            multiNodeSelecting: {
+              selecting: false,
+              anchor: {
+                x,
+                y
+              }
+            }
+          },
+          tr: {
+            setMeta: mockSetMeta
+          }
+        }
+      }
+    })
+    const domEvents = new MultipleNodeSelectionDomEvents(editor, {})
+
+    const event: Partial<DragEvent> = {
+      clientX: x,
+      clientY: y
+    }
+
+    expect(domEvents.dragstart(editor.view, event as any)).toBeFalsy()
+    expect(mockSetMeta).toBeCalledWith('multipleNodeSelectingEnd', true)
+  })
+
+  it('resolves position correctly', () => {
+    const editor = mockEditor()
+    const domEvents = new MultipleNodeSelectionDomEvents(editor, {})
+
+    expect(domEvents.resolvePosition(1, 2, 'anchor')).toBe(1)
+    expect(domEvents.resolvePosition(1, -1, 'anchor')).toBe(1)
+    expect(domEvents.resolvePosition(1, 2, 'head')).toBe(1)
+    expect(domEvents.resolvePosition(1, -1, 'head')).toBe(0)
+  })
+
+  describe('resolveCoordinates', () => {
+    it('resolves null if outside the document area correctly', () => {
+      const editor = mockEditor()
+      const domEvents = new MultipleNodeSelectionDomEvents(editor, {})
+
+      expect(
+        domEvents.resolveCoordinates({ x: 1, y: 1 }, { x: 10, y: 1 }, { top: 2, left: 2, bottom: 4, right: 4 })
+      ).toBeNull()
+
+      expect(
+        domEvents.resolveCoordinates({ x: 1, y: 10 }, { x: 10, y: 10 }, { top: 2, left: 2, bottom: 4, right: 4 })
+      ).toBeNull()
+
+      expect(
+        domEvents.resolveCoordinates({ x: 1, y: 3 }, { x: 1, y: 10 }, { top: 2, left: 2, bottom: 4, right: 4 })
+      ).toBeNull()
+
+      expect(
+        domEvents.resolveCoordinates({ x: 10, y: 3 }, { x: 10, y: 10 }, { top: 2, left: 2, bottom: 4, right: 4 })
+      ).toBeNull()
+    })
+
+    it('resolves coordinates correctly', () => {
+      const editor = mockEditor()
+      const domEvents = new MultipleNodeSelectionDomEvents(editor, {})
+
+      expect(
+        domEvents.resolveCoordinates({ x: 1, y: 3 }, { x: 10, y: 3 }, { top: 2, left: 2, bottom: 4, right: 4 })
+      ).toMatchObject({
+        anchor: {
+          x: 2,
+          y: 3
+        },
+        head: {
+          x: 4,
+          y: 3
+        }
+      })
+    })
+  })
+})

--- a/packages/editor/src/extensions/extensions/selection/decorations.ts
+++ b/packages/editor/src/extensions/extensions/selection/decorations.ts
@@ -17,7 +17,7 @@ export function textSelectionDecoration(
   if (!(state.selection instanceof TextSelection)) return null
 
   const { from, to } = state.selection
-  if (from === to) return null
+  if (state.selection.empty) return null
 
   const decorations: Decoration[] = []
 

--- a/packages/editor/src/extensions/extensions/selection/decorations.ts
+++ b/packages/editor/src/extensions/extensions/selection/decorations.ts
@@ -1,0 +1,52 @@
+import { Editor } from '@tiptap/core'
+import { EditorState, TextSelection, NodeSelection } from 'prosemirror-state'
+import { Decoration, DecorationSet } from 'prosemirror-view'
+import { SelectionOptions } from './meta'
+import { MultipleNodeSelection } from './MultipleNodeSelection'
+
+const DEFAULT_TEXT_SELECTION_CLASS = 'text-selection-highlight'
+const DEFAULT_NODE_SELECTION_CLASS = 'node-selection-highlight'
+
+export function textSelectionDecoration(
+  editor: Editor,
+  options: SelectionOptions,
+  state: EditorState
+): DecorationSet | null {
+  if (!editor.isEditable) return null
+
+  if (!(state.selection instanceof TextSelection)) return null
+
+  const { from, to } = state.selection
+  if (from === to) return null
+
+  const decorations: Decoration[] = []
+
+  const inlineDecoration = Decoration.inline(from, to, {
+    class: options.textSelection?.className ?? DEFAULT_TEXT_SELECTION_CLASS,
+    style: options.textSelection?.style
+  })
+  decorations.push(inlineDecoration)
+
+  return DecorationSet.create(editor.state.doc, decorations)
+}
+
+export function nodeSelectionDecoration(
+  editor: Editor,
+  options: SelectionOptions,
+  state: EditorState
+): DecorationSet | null {
+  if (!editor.isEditable) return null
+  if (!(state.selection instanceof MultipleNodeSelection) && !(state.selection instanceof NodeSelection)) return null
+
+  const decorations: Decoration[] = []
+
+  state.selection.ranges.forEach(range => {
+    const nodeDecoration = Decoration.node(range.$from.pos, range.$to.pos, {
+      class: options.nodeSelection?.className ?? DEFAULT_NODE_SELECTION_CLASS,
+      style: options.nodeSelection?.style
+    })
+    decorations.push(nodeDecoration)
+  })
+
+  return DecorationSet.create(state.doc, decorations)
+}

--- a/packages/editor/src/extensions/extensions/selection/domEvents.ts
+++ b/packages/editor/src/extensions/extensions/selection/domEvents.ts
@@ -111,6 +111,7 @@ export class MultipleNodeSelectionDomEvents {
 
     setTimeout(() => {
       view.dispatch(view.state.tr.setMeta('multipleNodeSelectingEnd', true))
+      this.editor.commands.focus()
     })
 
     return false

--- a/packages/editor/src/extensions/extensions/selection/domEvents.ts
+++ b/packages/editor/src/extensions/extensions/selection/domEvents.ts
@@ -1,0 +1,270 @@
+import { Editor } from '@tiptap/core'
+import { EditorView } from 'prosemirror-view'
+import { SelectionPluginKey, SelectionState } from './selection'
+
+export interface MultipleNodeSelectionDomEventsOptions {
+  mouseSelectionClassName?: string
+}
+
+export interface MultipleNodeSelectionContainer {
+  mouseSelection: {
+    id: string
+    element: HTMLElement | null
+  }
+  element: HTMLElement | null
+  top: number | undefined
+  left: number | undefined
+  offset: {
+    top: number
+    left: number
+  }
+}
+
+const initialContainer = (): MultipleNodeSelectionContainer => ({
+  element: null,
+  mouseSelection: {
+    id: 'multiple-node-selection-mouse-area',
+    element: null
+  },
+  top: undefined,
+  left: undefined,
+  offset: {
+    top: 0,
+    left: 0
+  }
+})
+
+export class MultipleNodeSelectionDomEvents {
+  public editor: Editor
+  public options: MultipleNodeSelectionDomEventsOptions
+  public container: MultipleNodeSelectionContainer = initialContainer()
+
+  constructor(editor: Editor, options: MultipleNodeSelectionDomEventsOptions) {
+    this.editor = editor
+    this.options = options
+  }
+
+  public mousedown(view: EditorView, event: MouseEvent): boolean {
+    const result = view.posAtCoords({ left: event.clientX, top: event.clientY })
+
+    // if click happens outside the doc nodes, assume a Multiple Node Selection will happen.
+    // so call blur to avoid Text Selection happen.
+    // case: result = null
+    // click outside the document
+    // case: result.inside === -1
+    // click on the doc node
+    if (!result || result.inside === -1) {
+      view.dispatch(
+        view.state.tr.setMeta('updateSelectionAnchor', {
+          x: event.clientX,
+          y: event.clientY
+        })
+      )
+
+      const mouseup = (event: MouseEvent): void => {
+        this.mouseup(view, event)
+
+        window.removeEventListener('mouseup', mouseup)
+        window.removeEventListener('mousemove', mousemove)
+        window.removeEventListener('dragstart', dragstart)
+      }
+
+      const mousemove = (event: MouseEvent): void => {
+        this.mousemove(view, event)
+      }
+
+      const dragstart = (event: DragEvent): void => {
+        this.dragstart(view, event)
+        window.removeEventListener('mouseup', mouseup)
+        window.removeEventListener('mousemove', mousemove)
+        window.removeEventListener('dragstart', dragstart)
+      }
+
+      window.addEventListener('mouseup', mouseup)
+      window.addEventListener('mousemove', mousemove)
+      window.addEventListener('dragstart', dragstart)
+    }
+
+    return false
+  }
+
+  public mousemove(view: EditorView, event: MouseEvent): boolean {
+    const pluginState = SelectionPluginKey.getState(view.state)
+    if (pluginState?.multiNodeSelecting) {
+      if (!pluginState.multiNodeSelecting.selecting) {
+        view.dispatch(view.state.tr.setMeta('multipleNodeSelecting', true))
+      }
+      const head = { x: event.clientX, y: event.clientY }
+      view.dispatch(view.state.tr.setMeta('updateSelectionHead', head))
+      this.renderMouseSelection(view, pluginState.multiNodeSelecting.anchor, head)
+      this.resolveSelection(view, pluginState, head, this.container.offset)
+    }
+
+    return false
+  }
+
+  public mouseup = (view: EditorView, event: MouseEvent): boolean => {
+    const element = document.getElementById(this.container.mouseSelection.id)
+    if (element) document.body.removeChild(element)
+
+    this.container = initialContainer()
+
+    setTimeout(() => {
+      view.dispatch(view.state.tr.setMeta('multipleNodeSelectingEnd', true))
+    })
+
+    return false
+  }
+
+  public dragstart = (view: EditorView, event: DragEvent): boolean => {
+    view.dispatch(view.state.tr.setMeta('multipleNodeSelectingEnd', true))
+    return false
+  }
+
+  private resolveCoordinates(
+    anchor: { x: number; y: number },
+    head: {
+      x: number
+      y: number
+    },
+    docRect: {
+      top: number
+      left: number
+      bottom: number
+      right: number
+    }
+  ): null | {
+    anchor: {
+      x: number
+      y: number
+    }
+    head: {
+      x: number
+      y: number
+    }
+  } {
+    if (anchor.y < docRect.top && head.y < docRect.top) return null
+    if (anchor.y > docRect.bottom && head.y > docRect.bottom) return null
+    if (anchor.x < docRect.left && head.x < docRect.left) return null
+    if (anchor.x > docRect.right && head.x > docRect.right) return null
+
+    // calculate the intersection of document area and user mouse selection area
+    const y1 = Math.max(Math.min(docRect.bottom, anchor.y), docRect.top)
+    const y2 = Math.max(Math.min(docRect.bottom, head.y), docRect.top)
+    const x1 = Math.min(Math.max(docRect.left, anchor.x), docRect.right)
+    const x2 = Math.min(Math.max(docRect.left, head.x), docRect.right)
+
+    return {
+      anchor: {
+        x: Math.min(x1, x2),
+        y: Math.min(y1, y2)
+      },
+      head: {
+        x: Math.min(x1, x2),
+        y: Math.max(y1, y2)
+      }
+    }
+  }
+
+  private resolvePosition(position: number, inside: number, type: 'anchor' | 'head'): number {
+    // if inside = -1, means position is not focus on any nodes
+    // we need move position to above one
+    if (inside === -1) return type === 'anchor' ? position : position - 1
+
+    // if inside is small than position, means the position is at the bottom edge of inside position
+    // if inside is bigger than position, means the position is at the top edge of inside position
+    return Math.min(position, inside)
+  }
+
+  private resolveSelection(
+    view: EditorView,
+    pluginState: SelectionState,
+    headCoords: { x: number; y: number },
+    offset: { top: number; left: number }
+  ): void {
+    if (!pluginState.multiNodeSelecting) return
+
+    const data = pluginState.multiNodeSelecting
+    const rect = view.dom.getBoundingClientRect()
+    const coordinates = this.resolveCoordinates(
+      {
+        x: data.anchor.x - offset.left,
+        y: data.anchor.y - offset.top
+      },
+      {
+        x: headCoords.x,
+        y: headCoords.y
+      },
+      rect
+    )
+
+    if (!coordinates) {
+      this.editor.commands.setTextSelection(0)
+      return
+    }
+
+    const anchor = view.posAtCoords({ left: coordinates.anchor.x, top: coordinates.anchor.y })
+    const head = view.posAtCoords({ left: coordinates.head.x, top: coordinates.head.y })
+
+    if (!anchor || !head) {
+      this.editor.commands.setTextSelection(0)
+      return
+    }
+
+    // selection do not include any nodes
+    if (anchor.inside === -1 && head.inside === -1 && Math.abs(anchor.pos - head.pos) <= 1) {
+      this.editor.commands.setTextSelection(0)
+      return
+    }
+
+    // console.log(anchor, head)
+
+    this.editor.commands.setMultipleNodeSelection(
+      this.resolvePosition(anchor.pos, anchor.inside, 'anchor'),
+      this.resolvePosition(head.pos, head.inside, 'head')
+    )
+  }
+
+  private renderMouseSelection(
+    view: EditorView,
+    anchor: { x: number; y: number },
+    head: { x: number; y: number }
+  ): void {
+    // initialize container information at start
+    if (!this.container.element) {
+      this.container.element = view.dom.parentElement
+    }
+    if (!this.container.element) return
+
+    const containerRect = this.container.element.getBoundingClientRect()
+
+    if (this.container.top === undefined) {
+      this.container.top = containerRect.top
+    }
+    if (this.container.left === undefined) {
+      this.container.left = containerRect.left
+    }
+
+    // create mouse selection element
+    if (!this.container.mouseSelection.element) {
+      const element = document.createElement('div')
+      element.id = this.container.mouseSelection.id
+      this.container.mouseSelection.element = element
+      document.body.append(element)
+      if (this.options.mouseSelectionClassName) {
+        this.container.mouseSelection.element.classList.add(this.options.mouseSelectionClassName)
+      }
+    }
+
+    // calculate offset
+    this.container.offset.top = this.container.top - containerRect.top
+    this.container.offset.left = this.container.left - containerRect.left
+
+    // calculate mouse selection position
+    this.container.mouseSelection.element.style.position = 'absolute'
+    this.container.mouseSelection.element.style.left = `${Math.min(anchor.x, head.x)}px`
+    this.container.mouseSelection.element.style.top = `${Math.min(anchor.y - this.container.offset.top, head.y)}px`
+    this.container.mouseSelection.element.style.width = `${Math.abs(anchor.x - head.x)}px`
+    this.container.mouseSelection.element.style.height = `${Math.abs(anchor.y - this.container.offset.top - head.y)}px`
+  }
+}

--- a/packages/editor/src/extensions/extensions/selection/domEvents.ts
+++ b/packages/editor/src/extensions/extensions/selection/domEvents.ts
@@ -121,7 +121,7 @@ export class MultipleNodeSelectionDomEvents {
     return false
   }
 
-  private resolveCoordinates(
+  public resolveCoordinates(
     anchor: { x: number; y: number },
     head: {
       x: number
@@ -160,13 +160,13 @@ export class MultipleNodeSelectionDomEvents {
         y: Math.min(y1, y2)
       },
       head: {
-        x: Math.min(x1, x2),
+        x: Math.max(x1, x2),
         y: Math.max(y1, y2)
       }
     }
   }
 
-  private resolvePosition(position: number, inside: number, type: 'anchor' | 'head'): number {
+  public resolvePosition(position: number, inside: number, type: 'anchor' | 'head'): number {
     // if inside = -1, means position is not focus on any nodes
     // we need move position to above one
     if (inside === -1) return type === 'anchor' ? position : position - 1
@@ -176,7 +176,7 @@ export class MultipleNodeSelectionDomEvents {
     return Math.min(position, inside)
   }
 
-  private resolveSelection(
+  public resolveSelection(
     view: EditorView,
     pluginState: SelectionState,
     headCoords: { x: number; y: number },
@@ -217,15 +217,13 @@ export class MultipleNodeSelectionDomEvents {
       return
     }
 
-    // console.log(anchor, head)
-
     this.editor.commands.setMultipleNodeSelection(
       this.resolvePosition(anchor.pos, anchor.inside, 'anchor'),
       this.resolvePosition(head.pos, head.inside, 'head')
     )
   }
 
-  private renderMouseSelection(
+  public renderMouseSelection(
     view: EditorView,
     anchor: { x: number; y: number },
     head: { x: number; y: number }

--- a/packages/editor/src/extensions/extensions/selection/meta.ts
+++ b/packages/editor/src/extensions/extensions/selection/meta.ts
@@ -1,11 +1,11 @@
 import { ExtensionMeta } from '../../common'
 
 export interface SelectionOptions {
-  textSelection: {
+  textSelection?: {
     className?: string
     style?: string
   }
-  nodeSelection: {
+  nodeSelection?: {
     mouseSelection?: {
       className?: string
     }

--- a/packages/editor/src/extensions/extensions/selection/meta.ts
+++ b/packages/editor/src/extensions/extensions/selection/meta.ts
@@ -6,6 +6,9 @@ export interface SelectionOptions {
     style?: string
   }
   nodeSelection: {
+    mouseArea?: {
+      className?: string
+    }
     className?: string
     style?: string
   }

--- a/packages/editor/src/extensions/extensions/selection/meta.ts
+++ b/packages/editor/src/extensions/extensions/selection/meta.ts
@@ -6,7 +6,7 @@ export interface SelectionOptions {
     style?: string
   }
   nodeSelection: {
-    mouseArea?: {
+    mouseSelection?: {
       className?: string
     }
     className?: string

--- a/packages/editor/src/extensions/extensions/selection/meta.ts
+++ b/packages/editor/src/extensions/extensions/selection/meta.ts
@@ -1,7 +1,14 @@
 import { ExtensionMeta } from '../../common'
 
 export interface SelectionOptions {
-  HTMLAttributes?: Record<string, string>
+  textSelection: {
+    className?: string
+    style?: string
+  }
+  nodeSelection: {
+    className?: string
+    style?: string
+  }
 }
 
 export interface SelectAttributes {}

--- a/packages/editor/src/extensions/extensions/selection/normalizeSelection.ts
+++ b/packages/editor/src/extensions/extensions/selection/normalizeSelection.ts
@@ -1,0 +1,33 @@
+import { Editor } from '@tiptap/core'
+import { ResolvedPos } from 'prosemirror-model'
+import { TextSelection, Selection } from 'prosemirror-state'
+import { EditorView } from 'prosemirror-view'
+import { findNodesInSelection } from '../../../helpers'
+import { SelectionPluginKey } from './selection'
+
+export function normalizeSelection(
+  editor: Editor,
+  view: EditorView,
+  $anchor: ResolvedPos,
+  $head: ResolvedPos
+): Selection | null {
+  if (!editor.isEditable) return null
+
+  const pluginState = SelectionPluginKey.getState(view.state)
+
+  if (pluginState?.multiNodeSelecting && pluginState.multiNodeSelecting.selecting) return view.state.selection
+
+  if ($anchor.pos === $head.pos) return null
+  if (!(view.state.selection instanceof TextSelection)) return null
+
+  // remove non-text node and empty text node selection by check: to - from > 1
+  // because we don't want non-text nodes at the end of Text Selection
+  // due to window.getSelection() will automatically select the nearest text if end of the selection is not a text node
+  const nodeRanges = findNodesInSelection(editor, $anchor.pos, $head.pos).filter(range => range.to - range.from > 1)
+  if (nodeRanges.length > 0) {
+    const to = nodeRanges[nodeRanges.length - 1].to
+    return TextSelection.create(view.state.doc, $anchor.pos, to)
+  }
+
+  return null
+}

--- a/packages/editor/src/extensions/extensions/selection/selection.ts
+++ b/packages/editor/src/extensions/extensions/selection/selection.ts
@@ -66,7 +66,8 @@ export const isTextContentSelected = ({ editor, from, to }: { editor: Editor; fr
   return show
 }
 
-export const DEFAULT_SELECTION_CLASS = 'editor-selection'
+const DEFAULT_TEXT_SELECTION_CLASS = 'text-selection-highlight'
+const DEFAULT_NODE_SELECTION_CLASS = 'node-selection-highlight'
 
 function resolveCoordinates(
   anchor: { x: number; y: number },
@@ -248,8 +249,8 @@ export const Selection = createExtension<SelectionOptions, SelectAttributes>({
 
             if (state.selection instanceof TextSelection) {
               const inlineDecoration = Decoration.inline(from, to, {
-                class: this.options.HTMLAttributes?.class ?? DEFAULT_SELECTION_CLASS,
-                style: this.options.HTMLAttributes?.style
+                class: this.options.textSelection?.className ?? DEFAULT_TEXT_SELECTION_CLASS,
+                style: this.options.textSelection?.style
               })
               decorations.push(inlineDecoration)
 
@@ -259,8 +260,8 @@ export const Selection = createExtension<SelectionOptions, SelectAttributes>({
             if (state.selection instanceof MultipleNodeSelection) {
               state.selection.ranges.forEach(range => {
                 const nodeDecoration = Decoration.node(range.$from.pos, range.$to.pos, {
-                  class: this.options.HTMLAttributes?.class ?? DEFAULT_SELECTION_CLASS,
-                  style: this.options.HTMLAttributes?.style
+                  class: this.options.nodeSelection?.className ?? DEFAULT_NODE_SELECTION_CLASS,
+                  style: this.options.nodeSelection?.style
                 })
                 decorations.push(nodeDecoration)
               })

--- a/packages/editor/src/extensions/extensions/selection/selection.ts
+++ b/packages/editor/src/extensions/extensions/selection/selection.ts
@@ -45,7 +45,7 @@ export const Selection = createExtension<SelectionOptions, SelectAttributes>({
 
   addCommands() {
     const domEvents = new MultipleNodeSelectionDomEvents(this.editor, {
-      mouseSelectionClassName: this.options.nodeSelection.mouseSelection?.className
+      mouseSelectionClassName: this.options.nodeSelection?.mouseSelection?.className
     })
 
     return {
@@ -77,7 +77,7 @@ export const Selection = createExtension<SelectionOptions, SelectAttributes>({
 
   addProseMirrorPlugins() {
     const domEvents = new MultipleNodeSelectionDomEvents(this.editor, {
-      mouseSelectionClassName: this.options.nodeSelection.mouseSelection?.className
+      mouseSelectionClassName: this.options.nodeSelection?.mouseSelection?.className
     })
     return [
       new Plugin<SelectionState>({

--- a/packages/editor/src/extensions/extensions/selection/selection.ts
+++ b/packages/editor/src/extensions/extensions/selection/selection.ts
@@ -1,19 +1,10 @@
-import { Editor, SingleCommands } from '@tiptap/core'
-import { Plugin, PluginKey, EditorState, TextSelection } from 'prosemirror-state'
-import { Decoration, DecorationSet, EditorView } from 'prosemirror-view'
-import { findNodesInSelection } from '../../../helpers'
+import { Plugin, PluginKey, EditorState } from 'prosemirror-state'
 import { createExtension } from '../../common'
 import { meta, SelectAttributes, SelectionOptions } from './meta'
-import { meta as paragraphMeta } from '../../blocks/paragraph/meta'
-import { meta as headingMeta } from '../../blocks/heading/meta'
-import { meta as listItemMeta } from '../../blocks/listItem/meta'
-import { meta as orderedListMeta } from '../../blocks/orderedList/meta'
-import { meta as bulletListMeta } from '../../blocks/bulletList/meta'
-import { meta as taskItemMeta } from '../../blocks/taskItem/meta'
-import { meta as taskListMeta } from '../../blocks/taskList/meta'
-import { meta as calloutMeta } from '../../blocks/callout/meta'
-import { meta as blockquoteMeta } from '../../blocks/blockquote/meta'
 import { MultipleNodeSelection } from './MultipleNodeSelection'
+import { nodeSelectionDecoration, textSelectionDecoration } from './decorations'
+import { normalizeSelection } from './normalizeSelection'
+import { MultipleNodeSelectionDomEvents } from './domEvents'
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
@@ -30,167 +21,7 @@ declare module '@tiptap/core' {
   }
 }
 
-const allowedNodeTypes = [
-  paragraphMeta.name,
-  headingMeta.name,
-  listItemMeta.name,
-  orderedListMeta.name,
-  bulletListMeta.name,
-  taskItemMeta.name,
-  taskListMeta.name,
-  calloutMeta.name,
-  blockquoteMeta.name
-]
-
-export const isTextContentSelected = ({ editor, from, to }: { editor: Editor; from: number; to: number }): boolean => {
-  if (!editor.isEditable || editor.isDestroyed) return false
-  if (from === to) return false
-
-  const isEmpty = editor.state.doc.textBetween(from, to).length === 0
-
-  if (isEmpty) return false
-
-  let show = false
-
-  const nodes = findNodesInSelection(editor, from, to)
-
-  for (const { node } of nodes) {
-    if (node) {
-      // Text node
-      if (node.type.name === 'text') {
-        show = true
-      } else if (allowedNodeTypes.includes(node.type.name)) {
-        show = true
-      } else {
-        return false
-      }
-    }
-  }
-
-  return show
-}
-
-const DEFAULT_TEXT_SELECTION_CLASS = 'text-selection-highlight'
-const DEFAULT_NODE_SELECTION_CLASS = 'node-selection-highlight'
-
-function resolveCoordinates(
-  anchor: { x: number; y: number },
-  head: {
-    x: number
-    y: number
-  },
-  docRect: {
-    top: number
-    left: number
-    bottom: number
-    right: number
-  }
-): null | {
-  anchor: {
-    x: number
-    y: number
-  }
-  head: {
-    x: number
-    y: number
-  }
-} {
-  if (anchor.y < docRect.top && head.y < docRect.top) return null
-  if (anchor.y > docRect.bottom && head.y > docRect.bottom) return null
-  if (anchor.x < docRect.left && head.x < docRect.left) return null
-  if (anchor.x > docRect.right && head.x > docRect.right) return null
-
-  // because of the behavior of `view.posAtCoords`
-  // we have to lock the anchor as left top of the selecting area and
-  // the head as right bottom of the selecting area
-  const y1 = Math.max(Math.min(docRect.bottom, anchor.y), docRect.top)
-  const y2 = Math.max(Math.min(docRect.bottom, head.y), docRect.top)
-  const x1 = Math.max(Math.min(docRect.left, anchor.x), docRect.right)
-  const x2 = Math.max(Math.min(docRect.left, head.x), docRect.right)
-
-  return {
-    anchor: {
-      x: Math.min(x1, x2),
-      y: Math.min(y1, y2)
-    },
-    head: {
-      x: Math.min(x1, x2),
-      y: Math.max(y1, y2)
-    }
-  }
-}
-
-function startSelection(view: EditorView, event: MouseEvent, commands: SingleCommands): void {
-  const result = view.posAtCoords({ left: event.clientX, top: event.clientY })
-
-  // if click happens outside the doc nodes, assume a Multiple Node Selection will happen.
-  // so call blur to avoid Text Selection happen.
-  // case: result = null
-  // click outside the document
-  // case: result.inside === -1
-  // click on the doc node
-  if (!result || result.inside === -1) {
-    view.dispatch(
-      view.state.tr.setMeta('updateSelectionAnchor', {
-        x: event.clientX,
-        y: event.clientY
-      })
-    )
-  }
-}
-
-function resolveSelection(
-  editor: Editor,
-  view: EditorView,
-  pluginState: SelectionState,
-  headCoords: { x: number; y: number },
-  offset: { top: number; left: number }
-): void {
-  if (!pluginState.multiNodeSelecting) return
-
-  const data = pluginState.multiNodeSelecting
-
-  const rect = view.dom.getBoundingClientRect()
-
-  const coordinates = resolveCoordinates(
-    {
-      x: data.anchor.x - offset.left,
-      y: data.anchor.y - offset.top
-    },
-    {
-      x: headCoords.x,
-      y: headCoords.y
-    },
-    rect
-  )
-
-  if (!coordinates) {
-    editor.commands.setTextSelection(0)
-    return
-  }
-
-  const anchor = view.posAtCoords({ left: coordinates.anchor.x, top: coordinates.anchor.y })
-  const head = view.posAtCoords({ left: coordinates.head.x, top: coordinates.head.y })
-
-  if (!anchor || !head) {
-    editor.commands.setTextSelection(0)
-    return
-  }
-
-  if (anchor.inside === -1 && head.inside === -1 && Math.abs(anchor.pos - head.pos) <= 1) {
-    editor.commands.setTextSelection(0)
-    return
-  }
-
-  let anchorPos = Math.min(anchor.pos, anchor.inside)
-  anchorPos = anchorPos === -1 ? anchor.pos - 1 : anchorPos
-  let headPos = Math.min(head.pos, head.inside)
-  headPos = headPos === -1 ? head.pos - 1 : headPos
-
-  editor.commands.setMultipleNodeSelection(anchorPos, headPos)
-}
-
-interface SelectionState {
+export interface SelectionState {
   multiNodeSelecting:
     | false
     | {
@@ -209,100 +40,14 @@ interface SelectionState {
 
 export const SelectionPluginKey = new PluginKey<SelectionState>(meta.name)
 
-class SelectionView {
-  view: EditorView
-  editor: Editor
-  options: SelectionOptions
-
-  public containerTop: number | undefined
-
-  public offset: {
-    top: number
-    left: number
-  }
-
-  constructor(editor: Editor, view: EditorView, options: SelectionOptions) {
-    this.editor = editor
-    this.view = view
-    this.options = options
-
-    this.offset = {
-      top: 0,
-      left: 0
-    }
-
-    window.addEventListener('mouseup', this.mouseup)
-    window.addEventListener('mousemove', this.mousemove)
-    window.addEventListener('dragstart', this.dragstart)
-  }
-
-  drawMouseArea = (anchor: { x: number; y: number }, head: { x: number; y: number }) => {
-    let area = document.getElementById('selection-mouse-area')
-    if (!area) {
-      area = document.createElement('div')
-      area.id = 'selection-mouse-area'
-      document.body.append(area)
-    }
-
-    const container = this.view.dom.parentElement!
-    const containerRect = container.getBoundingClientRect()
-
-    if (!this.containerTop) {
-      this.containerTop = containerRect.top
-    }
-
-    this.offset.top = this.containerTop - containerRect.top
-
-    area.classList.add(this.options.nodeSelection.mouseArea?.className ?? '')
-    area.style.position = 'absolute'
-    area.style.left = `${Math.min(anchor.x, head.x)}px`
-    area.style.top = `${Math.min(anchor.y - this.offset.top, head.y)}px`
-    area.style.width = `${Math.abs(anchor.x - head.x)}px`
-    area.style.height = `${Math.abs(anchor.y - this.offset.top - head.y)}px`
-  }
-
-  clearMouseArea = () => {
-    const area = document.getElementById('selection-mouse-area')
-    // const container = this.view.dom.parentElement!
-    if (area) document.body.removeChild(area)
-  }
-
-  mousemove = (event: MouseEvent) => {
-    const pluginState = SelectionPluginKey.getState(this.view.state)
-    if (pluginState?.multiNodeSelecting) {
-      if (!pluginState.multiNodeSelecting.selecting) {
-        this.view.dispatch(this.view.state.tr.setMeta('multipleNodeSelecting', true))
-      }
-      const head = { x: event.clientX, y: event.clientY }
-      this.view.dispatch(this.view.state.tr.setMeta('updateSelectionHead', head))
-      this.drawMouseArea(pluginState.multiNodeSelecting.anchor, head)
-      resolveSelection(this.editor, this.view, pluginState, head, this.offset)
-    }
-  }
-
-  mouseup = (event: MouseEvent) => {
-    this.clearMouseArea()
-    this.containerTop = undefined
-    this.offset = { left: 0, top: 0 }
-    setTimeout(() => {
-      this.view.dispatch(this.view.state.tr.setMeta('multipleNodeSelectingEnd', true))
-    })
-  }
-
-  dragstart = (event: DragEvent) => {
-    this.view.dispatch(this.view.state.tr.setMeta('multipleNodeSelectingEnd', true))
-  }
-
-  destroy(): void {
-    window.removeEventListener('mouseup', this.mouseup)
-    window.removeEventListener('mousemove', this.mousemove)
-  }
-}
-
 export const Selection = createExtension<SelectionOptions, SelectAttributes>({
   name: meta.name,
 
   addCommands() {
+    const domEvents = new MultipleNodeSelectionDomEvents(this.editor, {
+      mouseSelectionClassName: this.options.nodeSelection.mouseSelection?.className
+    })
+
     return {
       setMultipleNodeSelection:
         (anchor, head) =>
@@ -323,14 +68,17 @@ export const Selection = createExtension<SelectionOptions, SelectAttributes>({
         },
       startMultipleNodeSelection:
         event =>
-        ({ view, commands }) => {
-          startSelection(view, event, commands)
+        ({ view }) => {
+          domEvents.mousedown(view, event)
           return true
         }
     }
   },
 
   addProseMirrorPlugins() {
+    const domEvents = new MultipleNodeSelectionDomEvents(this.editor, {
+      mouseSelectionClassName: this.options.nodeSelection.mouseSelection?.className
+    })
     return [
       new Plugin<SelectionState>({
         key: SelectionPluginKey,
@@ -363,64 +111,19 @@ export const Selection = createExtension<SelectionOptions, SelectAttributes>({
             return { ...value }
           }
         },
-        view: view => new SelectionView(this.editor, view, this.options),
         props: {
           handleDOMEvents: {
-            mousedown: (view, event) => {
-              startSelection(view, event, this.editor.commands)
-              return false
-            }
+            mousedown: (view, event) => domEvents.mousedown(view, event)
           },
           decorations: (state: EditorState) => {
-            const { from, to } = state.selection
-            const decorations: Decoration[] = []
+            const textDecorationSet = textSelectionDecoration(this.editor, this.options, state)
 
-            if (!this.editor.isEditable) return
-            if (state.selection instanceof TextSelection && from === to) return
+            if (textDecorationSet) return textDecorationSet
 
-            if (state.selection instanceof TextSelection) {
-              const inlineDecoration = Decoration.inline(from, to, {
-                class: this.options.textSelection?.className ?? DEFAULT_TEXT_SELECTION_CLASS,
-                style: this.options.textSelection?.style
-              })
-              decorations.push(inlineDecoration)
-
-              return DecorationSet.create(this.editor.state.doc, decorations)
-            }
-
-            if (state.selection instanceof MultipleNodeSelection) {
-              state.selection.ranges.forEach(range => {
-                const nodeDecoration = Decoration.node(range.$from.pos, range.$to.pos, {
-                  class: this.options.nodeSelection?.className ?? DEFAULT_NODE_SELECTION_CLASS,
-                  style: this.options.nodeSelection?.style
-                })
-                decorations.push(nodeDecoration)
-              })
-
-              return DecorationSet.create(this.editor.state.doc, decorations)
-            }
+            return nodeSelectionDecoration(this.editor, this.options, state)
           },
           createSelectionBetween: (view, $anchor, $head) => {
-            if (!this.editor.isEditable) return
-
-            const pluginState = SelectionPluginKey.getState(view.state)
-
-            if (pluginState?.multiNodeSelecting && pluginState.multiNodeSelecting.selecting) return view.state.selection
-
-            if ($anchor.pos === $head.pos) return
-            if (!(view.state.selection instanceof TextSelection)) return
-
-            // remove non-text node and empty text node selection by check: to - from > 1
-            // because we don't want non-text nodes at the end of Text Selection
-            // due to window.getSelection() will automatically select the nearest text if end of the selection is not a text node
-            const nodeRanges = findNodesInSelection(this.editor, $anchor.pos, $head.pos).filter(
-              range => range.to - range.from > 1
-            )
-
-            if (nodeRanges.length > 0) {
-              const to = nodeRanges[nodeRanges.length - 1].to
-              return TextSelection.create(view.state.doc, $anchor.pos, to)
-            }
+            return normalizeSelection(this.editor, view, $anchor, $head)
           }
         }
       })

--- a/packages/editor/src/extensions/extensions/selection/selection.ts
+++ b/packages/editor/src/extensions/extensions/selection/selection.ts
@@ -1,6 +1,6 @@
 import { Editor } from '@tiptap/core'
 import { Plugin, PluginKey, EditorState, TextSelection } from 'prosemirror-state'
-import { Decoration, DecorationSet } from 'prosemirror-view'
+import { Decoration, DecorationSet, EditorView } from 'prosemirror-view'
 import { findNodesInSelection } from '../../../helpers'
 import { createExtension } from '../../common'
 import { meta, SelectAttributes, SelectionOptions } from './meta'
@@ -13,6 +13,18 @@ import { meta as taskItemMeta } from '../../blocks/taskItem/meta'
 import { meta as taskListMeta } from '../../blocks/taskList/meta'
 import { meta as calloutMeta } from '../../blocks/callout/meta'
 import { meta as blockquoteMeta } from '../../blocks/blockquote/meta'
+import { MultipleNodeSelection } from './MultipleNodeSelection'
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    multipleNodeSelection: {
+      /**
+       * Set a multiple node selection
+       */
+      setMultipleNodeSelection: (anchor: number, head: number) => ReturnType
+    }
+  }
+}
 
 const allowedNodeTypes = [
   paragraphMeta.name,
@@ -56,14 +68,125 @@ export const isTextContentSelected = ({ editor, from, to }: { editor: Editor; fr
 
 export const DEFAULT_SELECTION_CLASS = 'editor-selection'
 
-interface SelectionState {
-  multiNodeSelecting: boolean
+function resolveCoordinates(
+  anchor: { x: number; y: number },
+  head: {
+    x: number
+    y: number
+  },
+  docRect: {
+    top: number
+    left: number
+    bottom: number
+    right: number
+  }
+): null | {
+  anchor: {
+    x: number
+    y: number
+  }
+  head: {
+    x: number
+    y: number
+  }
+} {
+  if (anchor.y < docRect.top && head.y < docRect.top) return null
+  if (anchor.y > docRect.bottom && head.y > docRect.bottom) return null
+  if (anchor.x < docRect.left && head.x < docRect.left) return null
+  if (anchor.x > docRect.right && head.x > docRect.right) return null
+
+  return {
+    anchor: {
+      x: Math.max(Math.min(docRect.right, anchor.x), docRect.left),
+      y: Math.max(Math.min(docRect.bottom, anchor.y), docRect.top)
+    },
+    head: {
+      x: Math.max(Math.min(docRect.right, head.x), docRect.left),
+      y: Math.max(Math.min(docRect.bottom, head.y), docRect.top)
+    }
+  }
 }
 
-export const SelectionPluginKey = new PluginKey(meta.name)
+function resolveSelection(editor: Editor, view: EditorView, pluginState: SelectionState, event: MouseEvent): void {
+  if (!pluginState.multiNodeSelecting) return
+
+  const { x, y } = pluginState.multiNodeSelecting
+  const rect = view.dom.getBoundingClientRect()
+
+  const coordinates = resolveCoordinates({ x, y }, { x: event.x, y: event.y }, rect)
+
+  if (!coordinates) return
+
+  const anchor = view.posAtCoords({ left: coordinates.anchor.x, top: coordinates.anchor.y })
+  const head = view.posAtCoords({ left: coordinates.head.x, top: coordinates.head.y })
+
+  if (!anchor || !head) return
+
+  if (anchor.pos === head.pos) return
+
+  editor.commands.setMultipleNodeSelection(anchor.pos, head.pos)
+}
+
+interface SelectionState {
+  multiNodeSelecting:
+    | false
+    | {
+        x: number
+        y: number
+      }
+}
+
+export const SelectionPluginKey = new PluginKey<SelectionState>(meta.name)
+
+class SelectionView {
+  view: EditorView
+  editor: Editor
+
+  constructor(editor: Editor, view: EditorView) {
+    this.editor = editor
+    this.view = view
+
+    window.addEventListener('mouseup', this.mouseup)
+  }
+
+  mouseup = (event: MouseEvent) => {
+    const pluginState = SelectionPluginKey.getState(this.view.state)
+    if (pluginState?.multiNodeSelecting) {
+      resolveSelection(this.editor, this.view, pluginState, event)
+      this.view.dispatch(this.view.state.tr.setMeta('multipleNodeSelectingEnd', true))
+      this.editor.commands.focus()
+    }
+  }
+
+  destroy(): void {
+    window.removeEventListener('mouseup', this.mouseup)
+  }
+}
 
 export const Selection = createExtension<SelectionOptions, SelectAttributes>({
   name: meta.name,
+
+  addCommands() {
+    return {
+      setMultipleNodeSelection:
+        (anchor, head) =>
+        ({ dispatch, tr }) => {
+          if (dispatch) {
+            const { doc } = tr
+            const minPos = TextSelection.atStart(doc).from
+            const maxPos = TextSelection.atEnd(doc).to
+
+            const resolvedAnchor = Math.max(Math.min(anchor, maxPos), minPos)
+            const resolvedHead = Math.max(Math.min(head, maxPos), minPos)
+            const selection = MultipleNodeSelection.create(doc, resolvedAnchor, resolvedHead)
+
+            tr.setSelection(selection)
+          }
+
+          return true
+        }
+    }
+  },
 
   addProseMirrorPlugins() {
     return [
@@ -76,9 +199,19 @@ export const Selection = createExtension<SelectionOptions, SelectAttributes>({
             }
           },
           apply(tr, value, oldState, newState) {
+            const coordinates = tr.getMeta('multipleNodeSelectingStart')
+            if (coordinates) {
+              return { ...value, multiNodeSelecting: coordinates }
+            }
+
+            if (tr.getMeta('multipleNodeSelectingEnd')) {
+              return { ...value, multiNodeSelecting: false }
+            }
+
             return { ...value }
           }
         },
+        view: view => new SelectionView(this.editor, view),
         props: {
           handleDOMEvents: {
             mousedown: (view, event) => {
@@ -87,12 +220,21 @@ export const Selection = createExtension<SelectionOptions, SelectAttributes>({
               // if click happens outside the doc nodes, assume a Multiple Node Selection will happen.
               // so call blur to avoid Text Selection happen.
               if (result?.inside === -1) {
+                view.dispatch(
+                  view.state.tr.setMeta('multipleNodeSelectingStart', {
+                    x: event.x,
+                    y: event.y
+                  })
+                )
                 this.editor.commands.blur()
               }
               return false
             },
-            mouseup: () => {
-              this.editor.commands.focus()
+            mousemove: (view, event) => {
+              const pluginState = SelectionPluginKey.getState(view.state)
+              if (!pluginState) return false
+
+              resolveSelection(this.editor, view, pluginState, event)
 
               return false
             }
@@ -101,18 +243,34 @@ export const Selection = createExtension<SelectionOptions, SelectAttributes>({
             const { from, to } = state.selection
             const decorations: Decoration[] = []
 
-            if (!this.editor.isEditable || from === to) return
+            if (!this.editor.isEditable) return
+            if (state.selection instanceof TextSelection && from === to) return
 
-            const inlineDecoration = Decoration.inline(from, to, {
-              class: this.options.HTMLAttributes?.class ?? DEFAULT_SELECTION_CLASS,
-              style: this.options.HTMLAttributes?.style
-            })
-            decorations.push(inlineDecoration)
+            if (state.selection instanceof TextSelection) {
+              const inlineDecoration = Decoration.inline(from, to, {
+                class: this.options.HTMLAttributes?.class ?? DEFAULT_SELECTION_CLASS,
+                style: this.options.HTMLAttributes?.style
+              })
+              decorations.push(inlineDecoration)
 
-            return DecorationSet.create(this.editor.state.doc, decorations)
+              return DecorationSet.create(this.editor.state.doc, decorations)
+            }
+
+            if (state.selection instanceof MultipleNodeSelection) {
+              state.selection.ranges.forEach(range => {
+                const nodeDecoration = Decoration.node(range.$from.pos, range.$to.pos, {
+                  class: this.options.HTMLAttributes?.class ?? DEFAULT_SELECTION_CLASS,
+                  style: this.options.HTMLAttributes?.style
+                })
+                decorations.push(nodeDecoration)
+              })
+
+              return DecorationSet.create(this.editor.state.doc, decorations)
+            }
           },
           createSelectionBetween: (view, $anchor, $head) => {
-            if (!this.editor.isEditable || $anchor.pos === $head.pos) return
+            if (!this.editor.isEditable) return
+            if ($anchor.pos === $head.pos) return
 
             // remove non-text node and empty text node selection by check: to - from > 1
             // because we don't want non-text nodes at the end of Text Selection


### PR DESCRIPTION
selects multiple nodes by the `mousemove` event.

- [x] can select multiple nodes and highlight them.
- [x] handle copy & paste event of selection correctly.
- [x] distinguish text selection class name and node selection class name.
- [x] fix the problem that mouse move won't scroll the view.
- [x] highlight the rectangle area user dragged.
- [x] allow trigger selection from outside of the document area.