### PR TITLE
Fix multiple node selection

### DIFF
--- a/apps/client-web/src/docs/pages/DocumentPage.tsx
+++ b/apps/client-web/src/docs/pages/DocumentPage.tsx
@@ -1,4 +1,4 @@
-import { FC, MouseEventHandler, useCallback, useEffect, useMemo, useState } from 'react'
+import { FC, MouseEventHandler, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Spin } from '@mashcard/design-system'
 import { EditorContent, useEditor } from '@mashcard/editor'
 import { DocumentTitle } from './components/DocumentTitle'
@@ -61,9 +61,14 @@ export const DocumentPage: FC<DocumentPageProps> = ({ mode }) => {
     if (!loading) setLatestLoading(false)
   }, [loading, setLatestLoading])
 
+  const pageRef = useRef<HTMLDivElement>(null)
+  const pageContentRef = useRef<HTMLDivElement>(null)
+
   // setup this mouse down handler to start node selection when click outside the document area
-  const handleMouseDown = useCallback<MouseEventHandler<HTMLDivElement>>(
+  const handleMultipleNodeSelectionMouseDown = useCallback<MouseEventHandler<HTMLDivElement>>(
     event => {
+      // only allows multiple node selection work on Page and PageContent
+      if (event.target !== pageRef.current && event.target !== pageContentRef.current) return
       editor?.commands.startMultipleNodeSelection(event.nativeEvent)
     },
     [editor?.commands]
@@ -81,13 +86,14 @@ export const DocumentPage: FC<DocumentPageProps> = ({ mode }) => {
     <>
       {docMeta.id && docMeta.documentInfo?.isDeleted && <TrashPrompt />}
       <Root.Page
+        ref={pageRef}
         width={{
           '@mdOnly': 'md',
           '@smDown': 'sm'
         }}
-        onMouseDown={handleMouseDown}>
+        onMouseDown={handleMultipleNodeSelectionMouseDown}>
         <DocumentTitle docBlock={currentRootBlock} editable={documentEditable} meta={meta} setMeta={setMeta} />
-        <Root.PageContent>
+        <Root.PageContent ref={pageContentRef}>
           <EditorContent
             editor={editor}
             editable={documentEditable}

--- a/packages/editor/src/extensions/extensions/selection/MultipleNodeSelection.ts
+++ b/packages/editor/src/extensions/extensions/selection/MultipleNodeSelection.ts
@@ -42,7 +42,7 @@ export class MultipleNodeSelection extends Selection {
         ranges.push(new SelectionRange(doc.resolve(from), doc.resolve(from + node.nodeSize)))
       }
     } else {
-      doc.nodesBetween(from, to + 1, (node, pos) => {
+      doc.nodesBetween(from, Math.min(to + 1, MultipleNodeSelection.atEnd(doc).to), (node, pos) => {
         ranges.push(new SelectionRange(doc.resolve(pos), doc.resolve(pos + node.nodeSize)))
         return false
       })

--- a/packages/editor/src/extensions/extensions/selection/__tests__/MultipleNodeBookmark.test.ts
+++ b/packages/editor/src/extensions/extensions/selection/__tests__/MultipleNodeBookmark.test.ts
@@ -1,0 +1,46 @@
+import { MultipleNodeBookmark } from '../MultipleNodeBookmark'
+import * as selections from '../MultipleNodeSelection'
+
+jest.mock('../MultipleNodeSelection.ts')
+
+describe('MultipleNodeBookmark', () => {
+  it('maps MultipleNodeBookmark correctly', () => {
+    const anchor = 1
+    const head = 2
+    const bookmark = new MultipleNodeBookmark(anchor, head)
+
+    const mapping = {
+      map: (position: number): number => position + 1
+    }
+    const newBookmark = bookmark.map(mapping as any)
+
+    expect(newBookmark.anchor).toBe(anchor + 1)
+    expect(newBookmark.head).toBe(head + 1)
+  })
+
+  it('resolves selection correctly', () => {
+    class MockMultipleNodeSelection {
+      public anchor: any
+      public head: any
+      constructor(anchor: any, head: any) {
+        this.anchor = anchor
+        this.head = head
+      }
+    }
+
+    jest
+      .spyOn(selections, 'MultipleNodeSelection')
+      .mockImplementation((anchor, head) => new MockMultipleNodeSelection(anchor, head) as any)
+    const anchor = 1
+    const head = 2
+    const bookmark = new MultipleNodeBookmark(anchor, head)
+
+    const doc = {
+      resolve: (position: number) => position + 1
+    }
+    const selection = bookmark.resolve(doc as any)
+
+    expect(selection.anchor).toBe(anchor + 1)
+    expect(selection.head).toBe(head + 1)
+  })
+})

--- a/packages/editor/src/extensions/extensions/selection/__tests__/normalizeSelection.test.ts
+++ b/packages/editor/src/extensions/extensions/selection/__tests__/normalizeSelection.test.ts
@@ -1,0 +1,154 @@
+import { TextSelection } from 'prosemirror-state'
+import { mockEditor } from '../../../../test'
+import { MultipleNodeSelectionDomEvents } from '../domEvents'
+import { normalizeSelection } from '../normalizeSelection'
+import * as helpers from '../../../../helpers/selection'
+import { NodeRange } from '@tiptap/core'
+
+jest.mock('../../../../helpers/selection.ts')
+
+describe('normalizeSelection', () => {
+  it('returns null if editor is not editable', () => {
+    const editor = mockEditor({
+      isEditable: false
+    })
+    const $anchor = { pos: 1 }
+    const $head = { pos: 2 }
+
+    const selection = normalizeSelection(editor, editor.view, $anchor as any, $head as any)
+
+    expect(selection).toBeNull()
+  })
+
+  it('returns current selection if multiple node selection is selecting', () => {
+    const editor = mockEditor({
+      isEditable: true,
+      view: {
+        state: {
+          selection: {}
+        }
+      }
+    })
+    const $anchor = { pos: 1 }
+    const $head = { pos: 2 }
+
+    MultipleNodeSelectionDomEvents.selecting = true
+
+    const selection = normalizeSelection(editor, editor.view, $anchor as any, $head as any)
+
+    expect(selection).toBe(editor.view.state.selection)
+  })
+
+  it('returns null if selection has no length', () => {
+    const editor = mockEditor({
+      isEditable: true,
+      view: {
+        state: {
+          selection: {}
+        }
+      }
+    })
+    const $anchor = { pos: 1 }
+    const $head = { pos: 1 }
+
+    MultipleNodeSelectionDomEvents.selecting = false
+
+    const selection = normalizeSelection(editor, editor.view, $anchor as any, $head as any)
+
+    expect(selection).toBeNull()
+  })
+
+  it('returns null if current selection is TextSelection', () => {
+    const editor = mockEditor({
+      isEditable: true
+    })
+    const $anchor = { pos: 1 }
+    const $head = { pos: 2 }
+
+    MultipleNodeSelectionDomEvents.selecting = false
+
+    const selection = normalizeSelection(editor, editor.view, $anchor as any, $head as any)
+
+    expect(selection).toBeNull()
+  })
+
+  it('filters empty nodes in text selection tail', () => {
+    const nodeRanges: NodeRange[] = [
+      {
+        node: {} as any,
+        from: 0,
+        to: 5
+      },
+      {
+        node: {} as any,
+        from: 5,
+        to: 10
+      },
+      {
+        node: {} as any,
+        from: 10,
+        to: 11
+      }
+    ]
+    jest.spyOn(helpers, 'findNodesInSelection').mockImplementation(() => nodeRanges)
+    const createTextSelection = jest.fn()
+    jest.spyOn(TextSelection, 'create').mockImplementation(createTextSelection)
+
+    const currentSelection = Object.create(TextSelection.prototype)
+    const editor = mockEditor({
+      isEditable: true,
+      view: {
+        state: {
+          selection: currentSelection
+        }
+      }
+    })
+    const $anchor = { pos: 1 }
+    const $head = { pos: 2 }
+
+    MultipleNodeSelectionDomEvents.selecting = false
+
+    normalizeSelection(editor, editor.view, $anchor as any, $head as any)
+
+    expect(createTextSelection).toBeCalled()
+  })
+
+  it('returns null if all nodes in text selection is empty', () => {
+    const nodeRanges: NodeRange[] = [
+      {
+        node: {} as any,
+        from: 0,
+        to: 1
+      },
+      {
+        node: {} as any,
+        from: 1,
+        to: 2
+      },
+      {
+        node: {} as any,
+        from: 2,
+        to: 3
+      }
+    ]
+    jest.spyOn(helpers, 'findNodesInSelection').mockImplementation(() => nodeRanges)
+
+    const currentSelection = Object.create(TextSelection.prototype)
+    const editor = mockEditor({
+      isEditable: true,
+      view: {
+        state: {
+          selection: currentSelection
+        }
+      }
+    })
+    const $anchor = { pos: 1 }
+    const $head = { pos: 2 }
+
+    MultipleNodeSelectionDomEvents.selecting = false
+
+    const selection = normalizeSelection(editor, editor.view, $anchor as any, $head as any)
+
+    expect(selection).toBeNull()
+  })
+})

--- a/packages/editor/src/extensions/extensions/selection/domEvents.ts
+++ b/packages/editor/src/extensions/extensions/selection/domEvents.ts
@@ -135,7 +135,6 @@ export class MultipleNodeSelectionDomEvents {
     if (this.container.mouseSelection.anchor) {
       this.markSelecting(true)
       const head = { x: event.clientX, y: event.clientY }
-      view.dispatch(view.state.tr.setMeta('updateSelectionHead', head))
       this.renderMouseSelection(view, this.container.mouseSelection.anchor, head)
       this.resolveSelection(view, head)
     }

--- a/packages/editor/src/extensions/extensions/selection/domEvents.ts
+++ b/packages/editor/src/extensions/extensions/selection/domEvents.ts
@@ -91,46 +91,38 @@ export class MultipleNodeSelectionDomEvents {
   }
 
   public mousedown(view: EditorView, event: MouseEvent): boolean {
-    const result = view.posAtCoords({ left: event.clientX, top: event.clientY })
-
-    // if click happens outside the doc nodes, assume a Multiple Node Selection will happen.
-    // case: result = null
-    // click outside the document
-    // case: result.inside === -1
-    // click on the doc node
-    if (!result || result.inside === -1) {
-      this.container.mouseSelection = {
-        ...this.container.mouseSelection,
-        anchor: {
-          x: event.clientX,
-          y: event.clientY
-        }
+    this.container.mouseSelection = {
+      ...this.container.mouseSelection,
+      anchor: {
+        x: event.clientX,
+        y: event.clientY
       }
-
-      const mouseup = (event: MouseEvent): void => {
-        this.mouseup(view, event)
-
-        window.removeEventListener('mouseup', mouseup)
-        window.removeEventListener('mousemove', mousemove)
-        window.removeEventListener('dragstart', dragstart)
-      }
-
-      const mousemove = (event: MouseEvent): void => {
-        this.mousemove(view, event)
-      }
-
-      const dragstart = (event: DragEvent): void => {
-        this.dragstart(view, event)
-        window.removeEventListener('mouseup', mouseup)
-        window.removeEventListener('mousemove', mousemove)
-        window.removeEventListener('dragstart', dragstart)
-      }
-
-      // register events inside the mousedown event for avoiding invalid event listener.
-      window.addEventListener('mouseup', mouseup)
-      window.addEventListener('mousemove', mousemove)
-      window.addEventListener('dragstart', dragstart)
     }
+
+    const mouseup = (event: MouseEvent): void => {
+      this.mouseup(view, event)
+
+      window.removeEventListener('mouseup', mouseup)
+      window.removeEventListener('mousemove', mousemove)
+      window.removeEventListener('dragstart', dragstart)
+    }
+
+    const mousemove = (event: MouseEvent): void => {
+      this.mousemove(view, event)
+    }
+
+    const dragstart = (event: DragEvent): void => {
+      this.dragstart(view, event)
+      window.removeEventListener('mouseup', mouseup)
+      window.removeEventListener('mousemove', mousemove)
+      window.removeEventListener('dragstart', dragstart)
+    }
+
+    // register events inside the mousedown event for avoiding invalid event listener.
+    window.addEventListener('mouseup', mouseup)
+    window.addEventListener('mousemove', mousemove)
+    window.addEventListener('dragstart', dragstart)
+    // }
 
     return false
   }

--- a/packages/editor/src/extensions/extensions/selection/normalizeSelection.ts
+++ b/packages/editor/src/extensions/extensions/selection/normalizeSelection.ts
@@ -3,7 +3,7 @@ import { ResolvedPos } from 'prosemirror-model'
 import { TextSelection, Selection } from 'prosemirror-state'
 import { EditorView } from 'prosemirror-view'
 import { findNodesInSelection } from '../../../helpers'
-import { SelectionPluginKey } from './selection'
+import { MultipleNodeSelectionDomEvents } from './domEvents'
 
 export function normalizeSelection(
   editor: Editor,
@@ -13,9 +13,7 @@ export function normalizeSelection(
 ): Selection | null {
   if (!editor.isEditable) return null
 
-  const pluginState = SelectionPluginKey.getState(view.state)
-
-  if (pluginState?.multiNodeSelecting && pluginState.multiNodeSelecting.selecting) return view.state.selection
+  if (MultipleNodeSelectionDomEvents.selecting) return view.state.selection
 
   if ($anchor.pos === $head.pos) return null
   if (!(view.state.selection instanceof TextSelection)) return null

--- a/packages/editor/src/extensions/extensions/selection/selection.ts
+++ b/packages/editor/src/extensions/extensions/selection/selection.ts
@@ -88,7 +88,15 @@ export const Selection = createExtension<SelectionOptions, SelectAttributes>({
         key: SelectionPluginKey,
         props: {
           handleDOMEvents: {
-            mousedown: (view, event) => domEvents.mousedown(view, event)
+            mousedown: (view, event) => {
+              if (!(event.target instanceof HTMLElement)) return false
+
+              // if click happens on the doc node, assume a Multiple Node Selection will happen.
+              // TODO: check ProseMirror className could be invalid someday.
+              if (!event.target.classList.contains('ProseMirror')) return false
+
+              return domEvents.mousedown(view, event)
+            }
           },
           decorations: (state: EditorState) => {
             const textDecorationSet = textSelectionDecoration(this.editor, this.options, state)

--- a/packages/editor/src/extensions/extensions/selection/selection.ts
+++ b/packages/editor/src/extensions/extensions/selection/selection.ts
@@ -75,6 +75,10 @@ export const Selection = createExtension<SelectionOptions, SelectAttributes>({
     }
   },
 
+  addStorage() {
+    return {}
+  },
+
   addProseMirrorPlugins() {
     const domEvents = new MultipleNodeSelectionDomEvents(this.editor, {
       mouseSelectionClassName: this.options.nodeSelection?.mouseSelection?.className
@@ -82,35 +86,6 @@ export const Selection = createExtension<SelectionOptions, SelectAttributes>({
     return [
       new Plugin<SelectionState>({
         key: SelectionPluginKey,
-        state: {
-          init() {
-            return {
-              multiNodeSelecting: false
-            }
-          },
-          apply(tr, value, oldState, newState) {
-            const anchor = tr.getMeta('updateSelectionAnchor')
-            if (anchor) {
-              return { ...value, multiNodeSelecting: { anchor, selecting: false } }
-            }
-
-            const head = tr.getMeta('updateSelectionHead')
-
-            if (head && value.multiNodeSelecting) {
-              return { ...value, multiNodeSelecting: { ...value.multiNodeSelecting, head } }
-            }
-
-            if (tr.getMeta('multipleNodeSelecting') && value.multiNodeSelecting) {
-              return { ...value, multiNodeSelecting: { ...value.multiNodeSelecting, selecting: true } }
-            }
-
-            if (tr.getMeta('multipleNodeSelectingEnd')) {
-              return { ...value, multiNodeSelecting: false }
-            }
-
-            return { ...value }
-          }
-        },
         props: {
           handleDOMEvents: {
             mousedown: (view, event) => domEvents.mousedown(view, event)


### PR DESCRIPTION
1. Maintains mouse selection state in the `MultipleNodeSelectionDomEvents` instance but not in the `Prosemirror` plugin state, to avoid dispatching a transaction that will cause the anchor to jump to an unexpected position.
2. Limits the `mousedown` event only be invoked on certain elements. fix #254 
3. Make sure `MultipleNodeSelection` will always be in the range of the document to avoid `mapping` operation errors. fix #252 