### PR TITLE
fix(editor): add placeholder to nodes

### DIFF
--- a/apps/server-monolith/config/locales/pwa.en-US.yml
+++ b/apps/server-monolith/config/locales/pwa.en-US.yml
@@ -68,9 +68,16 @@ en-US:
   editor:
     placeholder:
       blockquote: Type something...
+      code_block: Enter or copy the code
       callout: Type something...
-      listItem: Type something...
-      taskItem: Type something...
+      listItem: List
+      taskItem: To-do...
+      heading1: Heading 1
+      heading2: Heading 2
+      heading3: Heading 3
+      heading4: Heading 4
+      heading5: Heading 5
+      heading6: Heading 5
       default: Type '/' for commands
     copy_hint: Copied to clipboard.
     explorer_menu:
@@ -394,8 +401,8 @@ en-US:
         gallery:
           search:
             placeholder: Search...
-          label: Select a picture from Unsplash.
-          description: Unsplash image.
+          label: Add pictures from Unsplash.
+          description: Pictures from unsplash
     user_block:
       anonymous: Anonymous
     page_link_block:

--- a/packages/editor/__snapshots__/components/blockViews/CodeBlockView/__tests__/CodeBlockView.test.tsx.snap
+++ b/packages/editor/__snapshots__/components/blockViews/CodeBlockView/__tests__/CodeBlockView.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`CodeBlockView matches snapshot correctly 1`] = `
 <div>
   <div
-    class="mc-c-eUWdaU"
+    class="mc-c-eUWdaU mc-c-gzEzdA"
     data-node-view-wrapper=""
     style="pointer-events: unset; white-space: normal;"
   >

--- a/packages/editor/__snapshots__/components/blockViews/HeadingView/__tests__/HeadingView.test.tsx.snap
+++ b/packages/editor/__snapshots__/components/blockViews/HeadingView/__tests__/HeadingView.test.tsx.snap
@@ -4,10 +4,11 @@ exports[`HeadingView matches snapshot correctly 1`] = `
 <div>
   <div
     data-node-view-wrapper=""
-    style="pointer-events: unset; white-space: normal;"
+    style="position: relative; pointer-events: unset; white-space: normal;"
   >
     <h1
       as="h1"
+      class="mc-c-gkVTfJ mc-c-gkVTfJ-cOVgnz-level-1"
       data-node-view-content=""
       style="white-space: pre-wrap;"
     />
@@ -19,10 +20,11 @@ exports[`HeadingView renders correspond heading according to level level 2 1`] =
 <div>
   <div
     data-node-view-wrapper=""
-    style="pointer-events: unset; white-space: normal;"
+    style="position: relative; pointer-events: unset; white-space: normal;"
   >
     <h2
       as="h2"
+      class="mc-c-gkVTfJ mc-c-gkVTfJ-gPLAez-level-2"
       data-node-view-content=""
       style="white-space: pre-wrap;"
     />
@@ -34,10 +36,11 @@ exports[`HeadingView renders correspond heading according to level level 3 1`] =
 <div>
   <div
     data-node-view-wrapper=""
-    style="pointer-events: unset; white-space: normal;"
+    style="position: relative; pointer-events: unset; white-space: normal;"
   >
     <h3
       as="h3"
+      class="mc-c-gkVTfJ mc-c-gkVTfJ-llzMLw-level-3"
       data-node-view-content=""
       style="white-space: pre-wrap;"
     />
@@ -49,10 +52,11 @@ exports[`HeadingView renders correspond heading according to level level 4 1`] =
 <div>
   <div
     data-node-view-wrapper=""
-    style="pointer-events: unset; white-space: normal;"
+    style="position: relative; pointer-events: unset; white-space: normal;"
   >
     <h4
       as="h4"
+      class="mc-c-gkVTfJ mc-c-gkVTfJ-dWBeGD-level-4"
       data-node-view-content=""
       style="white-space: pre-wrap;"
     />
@@ -64,10 +68,11 @@ exports[`HeadingView renders correspond heading according to level level 5 1`] =
 <div>
   <div
     data-node-view-wrapper=""
-    style="pointer-events: unset; white-space: normal;"
+    style="position: relative; pointer-events: unset; white-space: normal;"
   >
     <h5
       as="h5"
+      class="mc-c-gkVTfJ mc-c-gkVTfJ-hCSGfy-level-5"
       data-node-view-content=""
       style="white-space: pre-wrap;"
     />

--- a/packages/editor/__snapshots__/editors/documentEditor/__tests__/documentEditor.test.tsx.snap
+++ b/packages/editor/__snapshots__/editors/documentEditor/__tests__/documentEditor.test.tsx.snap
@@ -16,13 +16,14 @@ exports[`documentEditor renders document editor correctly 1`] = `
         >
           <div
             data-node-view-wrapper=""
-            style="pointer-events: unset; white-space: normal;"
+            style="position: relative; pointer-events: unset; white-space: normal;"
           >
             <div
               class="mc-c-FZsgd"
             >
               <h1
                 as="h1"
+                class="mc-c-gkVTfJ mc-c-gkVTfJ-cOVgnz-level-1"
                 data-node-view-content=""
                 style="--selection-padding: calc((2.875rem - 1.875rem) / 2); --bgColor-padding: calc((2.875rem - 1.875rem) / 2); white-space: pre-wrap;"
               >
@@ -80,13 +81,14 @@ exports[`documentEditor renders document editor correctly 1`] = `
         >
           <div
             data-node-view-wrapper=""
-            style="pointer-events: unset; white-space: normal;"
+            style="position: relative; pointer-events: unset; white-space: normal;"
           >
             <div
               class="mc-c-FZsgd"
             >
               <h2
                 as="h2"
+                class="mc-c-gkVTfJ mc-c-gkVTfJ-gPLAez-level-2"
                 data-node-view-content=""
                 style="--selection-padding: calc((2rem - 1.625rem) / 2); --bgColor-padding: calc((2rem - 1.625rem) / 2); white-space: pre-wrap;"
               >
@@ -144,13 +146,14 @@ exports[`documentEditor renders document editor correctly 1`] = `
         >
           <div
             data-node-view-wrapper=""
-            style="pointer-events: unset; white-space: normal;"
+            style="position: relative; pointer-events: unset; white-space: normal;"
           >
             <div
               class="mc-c-FZsgd"
             >
               <h3
                 as="h3"
+                class="mc-c-gkVTfJ mc-c-gkVTfJ-llzMLw-level-3"
                 data-node-view-content=""
                 style="--selection-padding: calc((1.875rem - 1.375rem) / 2); --bgColor-padding: calc((1.875rem - 1.375rem) / 2); white-space: pre-wrap;"
               >
@@ -208,13 +211,14 @@ exports[`documentEditor renders document editor correctly 1`] = `
         >
           <div
             data-node-view-wrapper=""
-            style="pointer-events: unset; white-space: normal;"
+            style="position: relative; pointer-events: unset; white-space: normal;"
           >
             <div
               class="mc-c-FZsgd"
             >
               <h4
                 as="h4"
+                class="mc-c-gkVTfJ mc-c-gkVTfJ-dWBeGD-level-4"
                 data-node-view-content=""
                 style="--selection-padding: calc((1.875rem - 1.25rem) / 2); --bgColor-padding: calc((1.875rem - 1.25rem) / 2); white-space: pre-wrap;"
               >
@@ -272,13 +276,14 @@ exports[`documentEditor renders document editor correctly 1`] = `
         >
           <div
             data-node-view-wrapper=""
-            style="pointer-events: unset; white-space: normal;"
+            style="position: relative; pointer-events: unset; white-space: normal;"
           >
             <div
               class="mc-c-FZsgd"
             >
               <h5
                 as="h5"
+                class="mc-c-gkVTfJ mc-c-gkVTfJ-hCSGfy-level-5"
                 data-node-view-content=""
                 style="--selection-padding: calc((1.5rem - 1rem) / 2); --bgColor-padding: calc((1.5rem - 1rem) / 2); white-space: pre-wrap;"
               >

--- a/packages/editor/__snapshots__/extensions/blocks/codeBlock/__tests__/codeBlock.test.tsx.snap
+++ b/packages/editor/__snapshots__/extensions/blocks/codeBlock/__tests__/codeBlock.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`CodeBlock renders CodeBlock correctly 1`] = `
         class="react-renderer node-codeBlock"
       >
         <div
-          class="mc-c-eUWdaU"
+          class="mc-c-eUWdaU mc-c-gzEzdA"
           data-node-view-wrapper=""
           style="pointer-events: unset; white-space: normal;"
         >

--- a/packages/editor/__snapshots__/extensions/blocks/heading/__tests__/heading.test.tsx.snap
+++ b/packages/editor/__snapshots__/extensions/blocks/heading/__tests__/heading.test.tsx.snap
@@ -14,10 +14,11 @@ exports[`Heading renders Heading correctly 1`] = `
       >
         <div
           data-node-view-wrapper=""
-          style="pointer-events: unset; white-space: normal;"
+          style="position: relative; pointer-events: unset; white-space: normal;"
         >
           <h1
             as="h1"
+            class="mc-c-gkVTfJ mc-c-gkVTfJ-cOVgnz-level-1"
             data-node-view-content=""
             style="white-space: pre-wrap;"
           >
@@ -34,10 +35,11 @@ exports[`Heading renders Heading correctly 1`] = `
       >
         <div
           data-node-view-wrapper=""
-          style="pointer-events: unset; white-space: normal;"
+          style="position: relative; pointer-events: unset; white-space: normal;"
         >
           <h2
             as="h2"
+            class="mc-c-gkVTfJ mc-c-gkVTfJ-gPLAez-level-2"
             data-node-view-content=""
             style="white-space: pre-wrap;"
           >
@@ -54,10 +56,11 @@ exports[`Heading renders Heading correctly 1`] = `
       >
         <div
           data-node-view-wrapper=""
-          style="pointer-events: unset; white-space: normal;"
+          style="position: relative; pointer-events: unset; white-space: normal;"
         >
           <h3
             as="h3"
+            class="mc-c-gkVTfJ mc-c-gkVTfJ-llzMLw-level-3"
             data-node-view-content=""
             style="white-space: pre-wrap;"
           >
@@ -74,10 +77,11 @@ exports[`Heading renders Heading correctly 1`] = `
       >
         <div
           data-node-view-wrapper=""
-          style="pointer-events: unset; white-space: normal;"
+          style="position: relative; pointer-events: unset; white-space: normal;"
         >
           <h4
             as="h4"
+            class="mc-c-gkVTfJ mc-c-gkVTfJ-dWBeGD-level-4"
             data-node-view-content=""
             style="white-space: pre-wrap;"
           >
@@ -94,10 +98,11 @@ exports[`Heading renders Heading correctly 1`] = `
       >
         <div
           data-node-view-wrapper=""
-          style="pointer-events: unset; white-space: normal;"
+          style="position: relative; pointer-events: unset; white-space: normal;"
         >
           <h5
             as="h5"
+            class="mc-c-gkVTfJ mc-c-gkVTfJ-hCSGfy-level-5"
             data-node-view-content=""
             style="white-space: pre-wrap;"
           >

--- a/packages/editor/src/components/blockViews/BlockContainer/useDisableActionOptions.ts
+++ b/packages/editor/src/components/blockViews/BlockContainer/useDisableActionOptions.ts
@@ -1,7 +1,7 @@
 import { Editor } from '@tiptap/react'
 import { useMemo } from 'react'
 import { BlockContainerProps } from './BlockContainer'
-import { findParagraphWrapper } from '../../../extensions/extensions/placeholder/findParagraphWrapper'
+import { findParagraphWrapper } from '../../../extensions/extensions/placeholder/findWrapper'
 
 export function useDisableActionOptions(
   editor: Editor | null | undefined,

--- a/packages/editor/src/components/blockViews/CodeBlockView/CodeBlockView.tsx
+++ b/packages/editor/src/components/blockViews/CodeBlockView/CodeBlockView.tsx
@@ -1,9 +1,16 @@
 import { FC, useState } from 'react'
 import { LineDown, Check } from '@mashcard/design-icons'
-import { Menu, Input, Popover, Switch, styled, theme } from '@mashcard/design-system'
+import { Menu, Input, Popover, Switch, styled, theme, cx } from '@mashcard/design-system'
 import { NodeViewContent } from '@tiptap/react'
 import { BlockContainer } from '../BlockContainer'
-import { highlightStyle, ViewModeBar, CodeContainer, CodeScroll, SwitchContainer } from './styles/highlight.style'
+import {
+  highlightStyle,
+  ViewModeBar,
+  CodeContainer,
+  CodeScroll,
+  SwitchContainer,
+  placeholderStyle
+} from './styles/highlight.style'
 import { CodeBlockViewProps } from '../../../extensions/blocks/codeBlock/meta'
 import { CodeBlockAttributes } from '../../../extensions'
 import { languageNames } from '../../../extensions/blocks/codeBlock/refractorLanguagesBundle'
@@ -96,7 +103,7 @@ export const CodeBlockView: FC<CodeBlockViewProps> = ({ node, updateAttributes, 
     <BlockContainer
       editable="custom"
       node={node}
-      className={highlightStyle()}
+      className={cx(highlightStyle(), placeholderStyle())}
       getPos={getPos}
       deleteNode={deleteNode}
       actionOptions={actionOptions}>

--- a/packages/editor/src/components/blockViews/CodeBlockView/styles/highlight.style.ts
+++ b/packages/editor/src/components/blockViews/CodeBlockView/styles/highlight.style.ts
@@ -39,6 +39,20 @@ export const SwitchContainer = styled('div', {
   }
 })
 
+export const placeholderStyle = css({
+  code: {
+    '&:before': {
+      color: theme.colors.typeThirdary,
+      content: 'attr(data-placeholder)',
+      left: 0,
+      pointerEvents: 'none',
+      position: 'absolute',
+      top: 0,
+      whiteSpace: 'nowrap'
+    }
+  }
+})
+
 export const highlightStyle = css({
   'code[class*="language-"], pre[class*="language-"]': {
     color: theme.colors.typePrimary,

--- a/packages/editor/src/components/blockViews/HeadingView/HeadingView.tsx
+++ b/packages/editor/src/components/blockViews/HeadingView/HeadingView.tsx
@@ -4,6 +4,64 @@ import { css, theme } from '@mashcard/design-system'
 import { BlockContainer } from '../BlockContainer'
 import { HeadingViewProps } from '../../../extensions/blocks/heading/meta'
 
+const placeholderStyle = css({
+  '&:before': {
+    color: theme.colors.typeThirdary,
+    content: 'attr(data-placeholder)',
+    left: 0,
+    pointerEvents: 'none',
+    position: 'absolute',
+    top: 0,
+    whiteSpace: 'nowrap'
+  },
+  variants: {
+    level: {
+      1: {
+        '&:before': {
+          lineHeight: theme.lineHeights.title1,
+          height: theme.lineHeights.title1,
+          marginTop: theme.titleOffset.title1
+        }
+      },
+      2: {
+        '&:before': {
+          lineHeight: theme.lineHeights.title2,
+          height: theme.lineHeights.title2,
+          marginTop: theme.titleOffset.title2
+        }
+      },
+      3: {
+        '&:before': {
+          lineHeight: theme.lineHeights.title3,
+          height: theme.lineHeights.title3,
+          marginTop: theme.titleOffset.title3
+        }
+      },
+      4: {
+        '&:before': {
+          lineHeight: theme.lineHeights.title4,
+          height: theme.lineHeights.title4,
+          marginTop: theme.titleOffset.title4
+        }
+      },
+      5: {
+        '&:before': {
+          lineHeight: theme.lineHeights.title5,
+          height: theme.lineHeights.title5,
+          marginTop: theme.titleOffset.title5
+        }
+      },
+      6: {
+        '&:before': {
+          lineHeight: theme.lineHeights.title5,
+          height: theme.lineHeights.title5,
+          marginTop: theme.titleOffset.title5
+        }
+      }
+    }
+  }
+})
+
 const actionButtonStyle = css({
   include: ['flexCenter'],
   display: 'flex',
@@ -62,6 +120,7 @@ export const HeadingView: FC<HeadingViewProps> = ({ node, deleteNode, extension,
   }, [node.attrs.level])
 
   const actionButtonClassName = actionButtonStyle({ level: node.attrs.level })
+  const placeholderClassName = placeholderStyle({ level: node.attrs.level })
 
   const HTMLAttributes =
     (typeof extension.options?.HTMLAttributes === 'function'
@@ -74,10 +133,13 @@ export const HeadingView: FC<HeadingViewProps> = ({ node, deleteNode, extension,
       node={node}
       actionOptions={['cut', 'copy', 'delete', 'transform']}
       actionButtonClassName={actionButtonClassName}
+      style={{
+        position: 'relative'
+      }}
       getPos={getPos}
       deleteNode={deleteNode}
       contentForCopy={node.textContent}>
-      <NodeViewContent {...HTMLAttributes} as={as} />
+      <NodeViewContent {...HTMLAttributes} as={as} className={placeholderClassName} />
     </BlockContainer>
   )
 }

--- a/packages/editor/src/editors/documentEditor/documentEditor.tsx
+++ b/packages/editor/src/editors/documentEditor/documentEditor.tsx
@@ -226,6 +226,8 @@ export function useEditor(options: EditorOptions, deps?: DependencyList): Tiptap
               placeholder: {
                 placeholder: ({ wrapperNode }) => {
                   switch (wrapperNode?.type.name) {
+                    case Heading.name:
+                      return t(`placeholder.heading${wrapperNode.attrs.level}`)
                     case Blockquote.name:
                       return t(`placeholder.blockquote`)
                     case ListItem.name:
@@ -234,6 +236,8 @@ export function useEditor(options: EditorOptions, deps?: DependencyList): Tiptap
                       return t(`placeholder.taskItem`)
                     case Callout.name:
                       return t(`placeholder.callout`)
+                    case CodeBlock.name:
+                      return t(`placeholder.code_block`)
                     default:
                       return t(`placeholder.default`)
                   }

--- a/packages/editor/src/extensions/extensions/placeholder/__tests__/findWrapper.test.ts
+++ b/packages/editor/src/extensions/extensions/placeholder/__tests__/findWrapper.test.ts
@@ -1,0 +1,18 @@
+import { findParagraphWrapper, findWrapper } from '../findWrapper'
+
+jest.mock('@tiptap/react', () => ({
+  findParentNodeClosestToPos: (_pos: any, cb: Function) => {
+    const node = { type: { name: 'unknown' } }
+    return cb(node)
+  }
+}))
+
+describe('findWrapper', () => {
+  it('findWrapper returns undefined if no nodes matched', () => {
+    expect(findWrapper({} as any)).toBeUndefined()
+  })
+
+  it('findParagraphWrapper returns undefined if no nodes matched', () => {
+    expect(findParagraphWrapper({} as any)).toBeUndefined()
+  })
+})

--- a/packages/editor/src/extensions/extensions/placeholder/__tests__/placeholder.test.ts
+++ b/packages/editor/src/extensions/extensions/placeholder/__tests__/placeholder.test.ts
@@ -1,13 +1,13 @@
 import { PlaceholderOptions, updatePlaceholder } from '../..'
 import { mockEditor } from '../../../../test'
-import { Embed, Paragraph } from '../../../blocks'
-import * as helpers from '../findParagraphWrapper'
+import { CodeBlock, Embed, Heading, Paragraph } from '../../../blocks'
+import * as helpers from '../findWrapper'
 
-jest.mock('../findParagraphWrapper')
+jest.mock('../findWrapper')
 
 describe('Placeholder', () => {
   it('does not update placeholder if editor is not editable', () => {
-    jest.spyOn(helpers, 'findParagraphWrapper').mockImplementation(() => undefined)
+    jest.spyOn(helpers, 'findWrapper').mockImplementation(() => undefined)
 
     const paragraph = document.createElement('p')
     paragraph.setAttribute('data-placeholder', '')
@@ -25,7 +25,7 @@ describe('Placeholder', () => {
   })
 
   it('does not throw error if can not find paragraph dom', () => {
-    jest.spyOn(helpers, 'findParagraphWrapper').mockImplementation(() => undefined)
+    jest.spyOn(helpers, 'findWrapper').mockImplementation(() => undefined)
 
     const text = document.createElement('span')
 
@@ -58,8 +58,84 @@ describe('Placeholder', () => {
     expect(() => updatePlaceholder(editor, options, storage)).not.toThrow()
   })
 
-  it('updates placeholder correctly', () => {
-    jest.spyOn(helpers, 'findParagraphWrapper').mockImplementation(() => undefined)
+  it('updates placeholder in heading correctly', () => {
+    jest.spyOn(helpers, 'findWrapper').mockImplementation(() => undefined)
+
+    const h1 = document.createElement('h1')
+    h1.setAttribute('data-node-view-content', '')
+    const text = document.createElement('span')
+    h1.appendChild(text)
+
+    const editor = mockEditor({
+      view: {
+        domAtPos: () => ({
+          node: text
+        })
+      },
+      state: {
+        selection: {
+          anchor: 1,
+          $anchor: {
+            node: () => ({
+              type: {
+                name: Heading.name
+              },
+              isLeaf: false,
+              childCount: 0
+            })
+          }
+        }
+      }
+    })
+    const options: PlaceholderOptions = {
+      placeholder: 'placeholder'
+    }
+    const storage = {}
+    updatePlaceholder(editor, options, storage)
+
+    expect(h1.getAttribute('data-placeholder')).toBe(options.placeholder)
+  })
+
+  it('updates placeholder in code block correctly', () => {
+    jest.spyOn(helpers, 'findWrapper').mockImplementation(() => undefined)
+
+    const code = document.createElement('code')
+    code.setAttribute('data-node-view-content', '')
+    const text = document.createElement('span')
+    code.appendChild(text)
+
+    const editor = mockEditor({
+      view: {
+        domAtPos: () => ({
+          node: text
+        })
+      },
+      state: {
+        selection: {
+          anchor: 1,
+          $anchor: {
+            node: () => ({
+              type: {
+                name: CodeBlock.name
+              },
+              isLeaf: false,
+              childCount: 0
+            })
+          }
+        }
+      }
+    })
+    const options: PlaceholderOptions = {
+      placeholder: 'placeholder'
+    }
+    const storage = {}
+    updatePlaceholder(editor, options, storage)
+
+    expect(code.getAttribute('data-placeholder')).toBe(options.placeholder)
+  })
+
+  it('updates placeholder in paragraph correctly', () => {
+    jest.spyOn(helpers, 'findWrapper').mockImplementation(() => undefined)
 
     const paragraph = document.createElement('p')
     paragraph.setAttribute('data-node-view-content', '')
@@ -97,7 +173,7 @@ describe('Placeholder', () => {
   })
 
   it('updates placeholder correctly if focus deep inside paragraph', () => {
-    jest.spyOn(helpers, 'findParagraphWrapper').mockImplementation(() => undefined)
+    jest.spyOn(helpers, 'findWrapper').mockImplementation(() => undefined)
 
     const paragraph = document.createElement('p')
     paragraph.setAttribute('data-node-view-content', '')
@@ -137,7 +213,7 @@ describe('Placeholder', () => {
   })
 
   it('clears placeholder correctly when focus another paragraph', () => {
-    jest.spyOn(helpers, 'findParagraphWrapper').mockImplementation(() => undefined)
+    jest.spyOn(helpers, 'findWrapper').mockImplementation(() => undefined)
 
     const latestFocusedElement = document.createElement('p')
     latestFocusedElement.setAttribute('data-placeholder', 'placeholder')
@@ -180,7 +256,7 @@ describe('Placeholder', () => {
   })
 
   it('clears placeholder correctly when focus another block', () => {
-    jest.spyOn(helpers, 'findParagraphWrapper').mockImplementation(() => undefined)
+    jest.spyOn(helpers, 'findWrapper').mockImplementation(() => undefined)
 
     const latestFocusedElement = document.createElement('p')
     latestFocusedElement.setAttribute('data-placeholder', 'placeholder')

--- a/packages/editor/src/extensions/extensions/placeholder/findWrapper.ts
+++ b/packages/editor/src/extensions/extensions/placeholder/findWrapper.ts
@@ -4,8 +4,14 @@ import { meta as listItemMeta } from '../../blocks/listItem/meta'
 import { meta as taskItemMeta } from '../../blocks/taskItem/meta'
 import { meta as blockquoteMeta } from '../../blocks/blockquote/meta'
 import { meta as calloutMeta } from '../../blocks/callout/meta'
+import { meta as headingMeta } from '../../blocks/heading/meta'
+import { meta as codeBlockMeta } from '../../blocks/codeBlock/meta'
 
-const wrapperList = [listItemMeta.name, taskItemMeta.name, blockquoteMeta.name, calloutMeta.name]
+const paragraphWrapperList = [listItemMeta.name, taskItemMeta.name, blockquoteMeta.name, calloutMeta.name]
+const wrapperList = [...paragraphWrapperList, headingMeta.name, codeBlockMeta.name]
+
+export const findWrapper = (position: ResolvedPos): ProsemirrorNode | undefined =>
+  findParentNodeClosestToPos(position, node => wrapperList.includes(node.type.name))?.node
 
 export const findParagraphWrapper = (position: ResolvedPos): ProsemirrorNode | undefined =>
   findParentNodeClosestToPos(position, node => wrapperList.includes(node.type.name))?.node

--- a/packages/editor/src/extensions/extensions/placeholder/placeholder.ts
+++ b/packages/editor/src/extensions/extensions/placeholder/placeholder.ts
@@ -1,9 +1,19 @@
 import { Editor } from '@tiptap/core'
 import { Node as ProsemirrorNode } from 'prosemirror-model'
-import { Paragraph } from '../../blocks'
+import { CodeBlock, Heading, Paragraph } from '../../blocks'
 import { createExtension } from '../../common'
-import { findParagraphWrapper } from './findParagraphWrapper'
+import { findWrapper } from './findWrapper'
 import { meta, PlaceholderAttributes, PlaceholderOptions } from './meta'
+
+const findHeadingDom = (node: HTMLElement): HTMLElement | null => {
+  if (['H1', 'H2', 'H3', 'H4', 'H5', 'H6'].includes(node.tagName)) return node
+
+  const parent = node.parentElement
+
+  if (!parent) return null
+
+  return findHeadingDom(parent)
+}
 
 const findParagraphDom = (node: HTMLElement): HTMLElement | null => {
   if (node.tagName === 'P') return node
@@ -13,6 +23,16 @@ const findParagraphDom = (node: HTMLElement): HTMLElement | null => {
   if (!parent) return null
 
   return findParagraphDom(parent)
+}
+
+const findCodeDom = (node: HTMLElement): HTMLElement | null => {
+  if (node.tagName === 'CODE') return node
+
+  const parent = node.parentElement
+
+  if (!parent) return null
+
+  return findCodeDom(parent)
 }
 
 const getPlaceholderText = (
@@ -33,7 +53,33 @@ export const updatePlaceholder = (editor: Editor, options: PlaceholderOptions, s
   const { $anchor, anchor } = editor.state.selection
   const node = $anchor.node()
 
-  if (node.type.name === Paragraph.name) {
+  if (node.type.name === CodeBlock.name) {
+    const { node: dom } = editor.view.domAtPos(anchor)
+    const codeElement = findCodeDom(dom as HTMLElement)
+
+    // store the latest focused element
+    // so we can clear placeholder when anchor changed next time
+    storage.latestFocusedElement?.setAttribute('data-placeholder', '')
+
+    const isEmpty = !node.isLeaf && !node.childCount
+
+    const wrapperNode = isEmpty ? findWrapper($anchor) ?? null : null
+    codeElement?.setAttribute('data-placeholder', isEmpty ? getPlaceholderText(node, wrapperNode, options) : '')
+    storage.latestFocusedElement = codeElement
+  } else if (node.type.name === Heading.name) {
+    const { node: dom } = editor.view.domAtPos(anchor)
+    const headingElement = findHeadingDom(dom as HTMLElement)
+
+    // store the latest focused element
+    // so we can clear placeholder when anchor changed next time
+    storage.latestFocusedElement?.setAttribute('data-placeholder', '')
+
+    const isEmpty = !node.isLeaf && !node.childCount
+
+    const wrapperNode = isEmpty ? findWrapper($anchor) ?? null : null
+    headingElement?.setAttribute('data-placeholder', isEmpty ? getPlaceholderText(node, wrapperNode, options) : '')
+    storage.latestFocusedElement = headingElement
+  } else if (node.type.name === Paragraph.name) {
     const { node: dom } = editor.view.domAtPos(anchor)
     const paragraphElement = findParagraphDom(dom as HTMLElement)
 
@@ -42,9 +88,9 @@ export const updatePlaceholder = (editor: Editor, options: PlaceholderOptions, s
     storage.latestFocusedElement?.setAttribute('data-placeholder', '')
 
     const isEmpty = !node.isLeaf && !node.childCount
-    const wrapperNode = isEmpty ? findParagraphWrapper($anchor) ?? null : null
-    paragraphElement?.setAttribute('data-placeholder', isEmpty ? getPlaceholderText(node, wrapperNode, options) : '')
 
+    const wrapperNode = isEmpty ? findWrapper($anchor) ?? null : null
+    paragraphElement?.setAttribute('data-placeholder', isEmpty ? getPlaceholderText(node, wrapperNode, options) : '')
     storage.latestFocusedElement = paragraphElement
   } else {
     storage.latestFocusedElement?.setAttribute('data-placeholder', '')

--- a/packages/editor/src/extensions/extensions/slashCommands/slashCommands.tsx
+++ b/packages/editor/src/extensions/extensions/slashCommands/slashCommands.tsx
@@ -8,7 +8,7 @@ import { MashcardEventBus, EventSubscribed, SlashMenuHide, SlashMenuKeyboardEven
 import { addItemKey } from './recentItemsManager'
 import { meta } from './meta'
 import { createExtension } from '../../common'
-import { findParagraphWrapper } from '../placeholder/findParagraphWrapper'
+import { findParagraphWrapper } from '../placeholder/findWrapper'
 
 export const TRIGGER_CHAR = '/'
 const ALLOW_SPACES = false


### PR DESCRIPTION
fix #42

adds placeholder to `Heading`, `CodeBlock`, and `To-do` nodes.