### PR TITLE
fix(editor): makes image view looks normal under small window view

### DIFF
--- a/apps/client-web/src/docs_legacy/pages/DocumentPage.style.ts
+++ b/apps/client-web/src/docs_legacy/pages/DocumentPage.style.ts
@@ -18,12 +18,12 @@ export const PageContent = styled('div', {
 export const Page = styled('div', {
   flex: 1,
   borderRadius: '2px',
+  width: '100%',
   variants: {
     width: {
       md: {},
       sm: {
         padding: 0,
-        width: '100%',
         [`${PageContent}`]: {
           padding: '0 1rem'
         }

--- a/packages/editor/src/components/blockViews/EmbedView/embedViews/ImageView/ImageView.style.ts
+++ b/packages/editor/src/components/blockViews/EmbedView/embedViews/ImageView/ImageView.style.ts
@@ -11,13 +11,22 @@ export const EmbedToolbarContainer = styled('div', {
   pointerEvents: 'none',
   position: 'absolute',
   right: '.5rem',
-  transition: 'opacity 100ms ease-in-out'
+  transition: 'opacity 100ms ease-in-out',
+
+  variants: {
+    center: {
+      true: {
+        right: '50%',
+        transform: 'translateX(50%)'
+      },
+      false: {}
+    }
+  }
 })
 
 export const ImageViewContainer = styled('div', {
   display: 'inline-flex',
   maxWidth: '100%',
-  overflow: 'hidden',
   position: 'relative',
 
   '&:hover': {
@@ -35,6 +44,7 @@ export const ImageViewContainer = styled('div', {
 export const ImageViewLayout = styled('div', {
   display: 'flex',
   flexDirection: 'column',
+  overflow: 'hidden',
 
   variants: {
     align: {

--- a/packages/editor/src/components/blockViews/EmbedView/embedViews/ImageView/ImageView.tsx
+++ b/packages/editor/src/components/blockViews/EmbedView/embedViews/ImageView/ImageView.tsx
@@ -49,6 +49,8 @@ export const ImageView: FC<ImageViewProps> = props => {
 
   const isFullWidth = align === 'full-width'
   const width = isFullWidth ? '100%' : imageWidth
+  // make toolbar center when image is too small
+  const embedToolbarCenter = typeof width === 'number' && width < 300
 
   return (
     <BlockContainer
@@ -84,7 +86,7 @@ export const ImageView: FC<ImageViewProps> = props => {
             <PreviewButton data-testid={TEST_ID_ENUM.editor.imageBlock.zoomInButton.id} onDoubleClick={previewImage} />
           </Resizable>
           {documentEditable && (
-            <EmbedToolbarContainer>
+            <EmbedToolbarContainer center={embedToolbarCenter}>
               <EmbedToolbar
                 url={url}
                 displayName={displayName}


### PR DESCRIPTION
fix #145
fix #268

make `Page` component width always be `100%` to limit document `max-width`. cc @melchior-voidwolf 