### PR TITLE
Fix horizontal input rule

### DIFF
--- a/packages/editor/src/extensions/blocks/horizontalRule/horizontalRule.ts
+++ b/packages/editor/src/extensions/blocks/horizontalRule/horizontalRule.ts
@@ -2,11 +2,23 @@ import { ReactNodeViewRenderer } from '@tiptap/react'
 import { HorizontalRule as TiptapHorizontalRule } from '@tiptap/extension-horizontal-rule'
 import { HorizontalRuleView } from '../../../components/blockViews'
 import { meta } from './meta'
+import { nodeInputRule } from './inputRule'
 
 export const HorizontalRule = TiptapHorizontalRule.extend({
   name: meta.name,
 
+  selectable: false,
+
   addNodeView() {
     return ReactNodeViewRenderer(HorizontalRuleView)
+  },
+
+  addInputRules() {
+    return [
+      nodeInputRule({
+        find: /^(?:---|—-|___\s|\*\*\*\s)$/,
+        type: this.type
+      })
+    ]
   }
 })

--- a/packages/editor/src/extensions/blocks/horizontalRule/inputRule.ts
+++ b/packages/editor/src/extensions/blocks/horizontalRule/inputRule.ts
@@ -1,0 +1,25 @@
+import { ExtendedRegExpMatchArray, InputRule, InputRuleFinder } from '@tiptap/react'
+import { NodeType } from 'prosemirror-model'
+
+/**
+ * Build an input rule that adds horizontal rule when the
+ * matched text is typed into it.
+ */
+export function nodeInputRule(config: {
+  find: InputRuleFinder
+  type: NodeType
+  getAttributes?: Record<string, any> | ((match: ExtendedRegExpMatchArray) => Record<string, any>) | false | null
+}): InputRule {
+  return new InputRule({
+    find: config.find,
+    handler: ({ state, range, match }) => {
+      const { tr } = state
+      const start = Math.max(range.from - 1, 0)
+      const end = range.to
+
+      if (match[0]) {
+        tr.replaceWith(start, end, config.type.create())
+      }
+    }
+  })
+}

--- a/packages/editor/src/extensions/extensions/eventHandler/gapClickHandler.ts
+++ b/packages/editor/src/extensions/extensions/eventHandler/gapClickHandler.ts
@@ -1,6 +1,7 @@
 import { Editor } from '@tiptap/core'
-import Paragraph from '@tiptap/extension-paragraph'
+import { TextSelection } from 'prosemirror-state'
 import { EditorView } from 'prosemirror-view'
+import { Paragraph } from '../../blocks/paragraph'
 import { meta as paragraphMeta } from '../../blocks/paragraph/meta'
 import { meta as headingMeta } from '../../blocks/heading/meta'
 
@@ -15,13 +16,11 @@ export const gapClickHandler = (editor: Editor, view: EditorView, position: numb
     return
   }
 
-  // when clicked at the end of document, the latest two position will be null
-  if (position - 2 < 0) return
-  const node = view.state.doc.nodeAt(position - 2)
-  const nextNode = view.state.doc.nodeAt(position)
+  const endSelection = TextSelection.atEnd(editor.state.doc)
 
-  if (!nextNode) {
-    if (node && paragraphLikeBlockType.includes(node.type.name)) return
-    insertNewLine(editor, position)
-  }
+  if (position < endSelection.to) return
+  const node = endSelection.$to.node()
+
+  if (node && paragraphLikeBlockType.includes(node.type.name)) return
+  insertNewLine(editor, position)
 }


### PR DESCRIPTION
the tiptap function `nodeInputRule` will call `tr.replaceWith(range.from, range.to)` to apply node when input text matched the rule. Because the range is inside the `paragraph`, `replace` will only clear the content of `paragraph`, which remains an empty paragraph above the `horizontalRule`. To fix it we create our `nodeInputRule` for `horizontalRule` to call `tr.replaceWith(range.from - 1, range.to)` to replace the whole paragraph (which is the parent of the text content in the range).

ref:

https://github.com/ueberdosis/tiptap/blob/main/packages/core/src/inputRules/nodeInputRule.ts#L26-L47