### PR TITLE
refactor: ActiveStorage

### DIFF
--- a/apps/client-web/src/routes/$domain/$docId/_shared/DocumentEditor/useEditorOptions/useEmbed/useGetFileUrl.ts
+++ b/apps/client-web/src/routes/$domain/$docId/_shared/DocumentEditor/useEditorOptions/useEmbed/useGetFileUrl.ts
@@ -4,16 +4,22 @@ import { useCallback } from 'react'
 
 export function useGetFileUrl(docBlobs: Blob[]): EmbedOptions['getFileUrl'] {
   const getFileUrl = useCallback<NonNullable<EmbedOptions['getFileUrl']>>(
-    (key, source): string | undefined => {
-      if (source === 'EXTERNAL') return key
+    (key, source) => {
+      if (source === 'EXTERNAL') return { url: key, downloadUrl: key }
 
       const blobs =
         docBlobs.map(blob => ({
           key: blob.blobKey,
+          downloadUrl: blob.downloadUrl,
           url: blob.url
         })) ?? []
 
-      if (source === 'ORIGIN') return blobs.find(blob => blob.key === key)?.url
+      if (source === 'ORIGIN') {
+        const blob = blobs.find(blob => blob.key === key)
+        if (blob) {
+          return { url: blob.url, downloadUrl: blob.downloadUrl }
+        }
+      }
       return undefined
     },
     [docBlobs]

--- a/apps/server-monolith/Gemfile
+++ b/apps/server-monolith/Gemfile
@@ -40,6 +40,7 @@ gem 'rbnacl', '~> 7.1', '>= 7.1.1'
 gem 'dry-container', '~> 0.10.0'
 gem 'rails-i18n', '~> 7.0.0'
 gem 'default_value_for', github: 'mashcard/default_value_for'
+gem 'rack-cors'
 
 # Feature toggles
 gem 'flipper', '~> 0.25.0'

--- a/apps/server-monolith/Gemfile.lock
+++ b/apps/server-monolith/Gemfile.lock
@@ -364,6 +364,8 @@ GEM
     raabro (1.4.0)
     racc (1.6.0)
     rack (2.2.4)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-protection (2.2.1)
       rack
     rack-test (2.0.2)
@@ -620,6 +622,7 @@ DEPENDENCIES
   pg (~> 1.4.1)
   puma (~> 5.6.4)
   puma_worker_killer (~> 0.3.1)
+  rack-cors
   rails (= 7.0.3.1)
   rails-i18n (~> 7.0.0)
   rbnacl (~> 7.1, >= 7.1.1)

--- a/apps/server-monolith/app/graphql/mutations/create_direct_upload.rb
+++ b/apps/server-monolith/app/graphql/mutations/create_direct_upload.rb
@@ -20,6 +20,7 @@ module Mutations
 
       if type == 'DOC'
         raise Mashcard::GraphQL::Errors::ArgumentError, :need_block_id if args[:block_id].nil?
+
         block = Docs::Block.unscoped.find(args[:block_id])
         pod = block.pod
       else

--- a/apps/server-monolith/app/graphql/mutations/create_direct_upload.rb
+++ b/apps/server-monolith/app/graphql/mutations/create_direct_upload.rb
@@ -17,34 +17,34 @@ module Mutations
     def resolve(args)
       input = args[:input]
       type = args[:type]
+
+      if type == 'DOC'
+        raise Mashcard::GraphQL::Errors::ArgumentError, :need_block_id if args[:block_id].nil?
+        block = Docs::Block.unscoped.find(args[:block_id])
+        pod = block.pod
+      else
+        pod = current_user
+      end
+
       service = SERVICE_MAP.fetch(type)
       # https://edgeapi.rubyonrails.org/classes/ActiveStorage/Blob.html#method-c-create_before_direct_upload-21
       new_input = input.to_h.merge(service_name: service)
 
       block_id = args[:block_id] || 'global'
-      key = "#{current_pod.fetch('username')}/#{block_id}/#{ActiveStorage::Blob.generate_unique_secure_token}_#{input[:filename]}"
-      todo = new_input.merge(
-        key: key,
-        operation_type: type,
-        pod_id: current_pod.fetch('id'),
-        user_id: current_user.id,
-        block_id: args[:block_id]
-      )
-      Rails.logger.debug todo.to_json
+
+      key = "#{pod.username}/#{block_id}/#{ActiveStorage::Blob.generate_unique_secure_token}_#{input[:filename]}"
       # https://github.com/rails/rails/blob/main/activestorage/app/models/active_storage/blob.rb#L116
       blob = ActiveStorage::Blob.create!(
         new_input.merge(
           key: key,
           operation_type: type,
-          pod_id: current_pod.fetch('id'),
+          pod_id: pod.id,
           user_id: current_user.id,
           block_id: args[:block_id]
         )
       )
 
       if type == 'DOC'
-        raise Mashcard::GraphQL::Errors::ArgumentError, 'Need a block_id' if args[:block_id].nil?
-
         block = Docs::Block.find_by(id: args[:block_id])
 
         ## Ensure exist

--- a/apps/server-monolith/config/initializers/cors.rb
+++ b/apps/server-monolith/config/initializers/cors.rb
@@ -1,0 +1,11 @@
+if ENV['RAILS_ENV'] === 'development'
+  Rails.application.config.middleware.insert_before 0, Rack::Cors do
+    allow do
+      origins 'localhost:3000'
+
+      resource '*',
+        headers: :any,
+        methods: [:get, :post, :put, :patch, :delete, :options, :head]
+    end
+  end
+end

--- a/apps/server-monolith/config/initializers/cors.rb
+++ b/apps/server-monolith/config/initializers/cors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if ENV['RAILS_ENV'] === 'development'
   Rails.application.config.middleware.insert_before 0, Rack::Cors do
     allow do

--- a/apps/server-monolith/spec/graphql/mutations/create_direct_upload_spec.rb
+++ b/apps/server-monolith/spec/graphql/mutations/create_direct_upload_spec.rb
@@ -20,7 +20,6 @@ describe Mutations::CreateDirectUpload, type: :mutation do
 
     it 'avatar' do
       self.current_user = user
-      self.current_pod = user.personal_pod.as_session_context
       input = { input: { type: 'AVATAR',
                          input: { filename: 'foo.txt', checksum: '123123', byteSize: 123, contentType: 'text' }, } }
       graphql_execute(mutation, input)
@@ -28,12 +27,10 @@ describe Mutations::CreateDirectUpload, type: :mutation do
       expect(response.errors).to eq({})
       expect(response.data[:createDirectUpload][:directUpload][:viewUrl]).not_to be_blank
       self.current_user = nil
-      self.current_pod = nil
     end
 
     it 'doc' do
       self.current_user = user
-      self.current_pod = user.personal_pod.as_session_context
       block = create(:docs_block, pod: user.personal_pod)
       input = { input: { type: 'DOC', blockId: block.id,
                          input: { filename: 'foo.txt', checksum: '123123', byteSize: 123, contentType: 'text' }, } }
@@ -42,7 +39,6 @@ describe Mutations::CreateDirectUpload, type: :mutation do
       expect(response.errors).to eq({})
       expect(response.data[:createDirectUpload][:directUpload][:viewUrl]).not_to be_blank
       self.current_user = nil
-      self.current_pod = nil
     end
   end
 end

--- a/packages/legacy-editor/src/components/blockViews/EmbedView/EmbedView.tsx
+++ b/packages/legacy-editor/src/components/blockViews/EmbedView/EmbedView.tsx
@@ -16,6 +16,7 @@ export type UpdateEmbedBlockAttributes = <T extends 'link' | 'image' | 'attachme
 
 const renderImage = (
   imageUrl: string,
+  downloadUrl: string,
   updateEmbedBlockAttributes: UpdateEmbedBlockAttributes,
   { node, deleteNode, getPos, extension }: EmbedViewProps
 ): ReactElement => {
@@ -26,6 +27,7 @@ const renderImage = (
       <ImageView
         displayName={displayName! || name! || ''}
         url={imageUrl}
+        downloadUrl={downloadUrl}
         height={height}
         width={width}
         align={align}
@@ -46,6 +48,7 @@ const renderImage = (
         cover={imageUrl}
         icon={<FileIcon fileType="image" />}
         linkUrl={imageUrl}
+        downloadUrl={downloadUrl}
         node={node}
         extension={extension}
         deleteNode={deleteNode}
@@ -73,6 +76,7 @@ const renderImage = (
 
 const renderAttachment = (
   fileUrl: string,
+  downloadUrl: string,
   updateEmbedBlockAttributes: UpdateEmbedBlockAttributes,
   { node, deleteNode, extension, getPos }: EmbedViewProps
 ): ReactElement => {
@@ -88,6 +92,7 @@ const renderAttachment = (
         fileName={name ?? ''}
         fileType={fileType}
         fileUrl={fileUrl}
+        downloadUrl={downloadUrl}
         deleteNode={deleteNode}
         getPos={getPos}
         node={node}
@@ -105,6 +110,7 @@ const renderAttachment = (
         description={sizeFormat(size)}
         icon={<FileIcon fileType={fileType} />}
         linkUrl={fileUrl}
+        downloadUrl={downloadUrl}
         node={node}
         extension={extension}
         deleteNode={deleteNode}
@@ -161,20 +167,26 @@ export const EmbedView: FC<EmbedViewProps> = props => {
   )
   // image
   if (node.attrs.image?.key) {
-    const imageUrl =
-      extension.options.getFileUrl?.(node.attrs.image.key, node.attrs.image.source!) ?? node.attrs.image.viewUrl
+    const { url: imageUrl, downloadUrl } = extension.options.getFileUrl?.(
+      node.attrs.image.key,
+      node.attrs.image.source!
+    ) ?? {
+      url: node.attrs.image.viewUrl,
+      downloadUrl: node.attrs.image.downloadUrl!
+    }
     if (imageUrl) {
-      return renderImage(imageUrl, updateEmbedBlockAttributes, props)
+      return renderImage(imageUrl, downloadUrl, updateEmbedBlockAttributes, props)
     }
   }
 
   // file
   if (node.attrs.attachment?.key) {
-    const fileUrl =
-      node.attrs.attachment.viewUrl! ||
-      extension.options.getFileUrl?.(node.attrs.attachment.key, node.attrs.attachment.source!)
+    const { url: fileUrl, downloadUrl } = extension.options.getFileUrl?.(
+      node.attrs.attachment.key,
+      node.attrs.attachment.source!
+    ) ?? { url: node.attrs.attachment.viewUrl!, downloadUrl: node.attrs.attachment.downloadUrl! }
     if (fileUrl) {
-      return renderAttachment(fileUrl, updateEmbedBlockAttributes, props)
+      return renderAttachment(fileUrl, downloadUrl, updateEmbedBlockAttributes, props)
     }
   }
 
@@ -196,6 +208,7 @@ export const EmbedView: FC<EmbedViewProps> = props => {
           getPos={getPos}
           displayName={displayName! || title! || ''}
           linkUrl={linkUrl}
+          downloadUrl={linkUrl}
         />
       )
     }
@@ -208,6 +221,7 @@ export const EmbedView: FC<EmbedViewProps> = props => {
           node={node}
           extension={extension}
           fileUrl={linkUrl}
+          downloadUrl={linkUrl}
           iframeUrl={iframeUrl}
           fileType="html"
           fileName={title ?? ''}

--- a/packages/legacy-editor/src/components/blockViews/EmbedView/__tests__/embedViews/ImageView/useImageState.test.ts
+++ b/packages/legacy-editor/src/components/blockViews/EmbedView/__tests__/embedViews/ImageView/useImageState.test.ts
@@ -17,7 +17,7 @@ describe('useImageState', () => {
       }
     })
     const updateEmbedBlockAttributes = jest.fn()
-    const props: any = { displayName, url, node, updateEmbedBlockAttributes }
+    const props: any = { displayName, url, downloadUrl: url, node, updateEmbedBlockAttributes }
     const { result } = renderHook(() => useImageState(props))
 
     const { onImageLoad } = result.current
@@ -48,7 +48,7 @@ describe('useImageState', () => {
         }
       }
     })
-    const props: any = { displayName, url, node }
+    const props: any = { displayName, url, downloadUrl: url, node }
     const { result } = renderHook(() => useImageState(props))
 
     const { previewImage } = result.current
@@ -71,7 +71,7 @@ describe('useImageState', () => {
         }
       }
     })
-    const props: any = { displayName, url, node, updateEmbedBlockAttributes }
+    const props: any = { displayName, url, downloadUrl: url, node, updateEmbedBlockAttributes }
     const { result } = renderHook(() => useImageState(props))
 
     const { onImageLoad } = result.current
@@ -101,7 +101,7 @@ describe('useImageState', () => {
       }
     })
     const updateEmbedBlockAttributes = jest.fn()
-    const props: any = { displayName, url, node, updateEmbedBlockAttributes }
+    const props: any = { displayName, url, downloadUrl: url, node, updateEmbedBlockAttributes }
     const { result } = renderHook(() => useImageState(props))
 
     const { zoomInImage } = result.current
@@ -124,7 +124,7 @@ describe('useImageState', () => {
       }
     })
     const updateEmbedBlockAttributes = jest.fn()
-    const props: any = { displayName, url, node, updateEmbedBlockAttributes }
+    const props: any = { displayName, url, downloadUrl: url, node, updateEmbedBlockAttributes }
     const { result } = renderHook(() => useImageState(props))
 
     const { zoomOutImage } = result.current

--- a/packages/legacy-editor/src/components/blockViews/EmbedView/embedViews/CardView/CardView.tsx
+++ b/packages/legacy-editor/src/components/blockViews/EmbedView/embedViews/CardView/CardView.tsx
@@ -30,6 +30,7 @@ export interface CardViewProps {
   displayName: string
   description?: string | null
   linkUrl: string
+  downloadUrl: string
   updateEmbedBlockAttributes: UpdateEmbedBlockAttributes
   blockType: EmbedBlockType
 }
@@ -56,6 +57,7 @@ export const CardIcon: FC<Pick<CardViewProps, 'blockType' | 'icon'>> = ({ blockT
 
 export const CardView: FC<CardViewProps> = ({
   linkUrl,
+  downloadUrl,
   cover,
   icon,
   displayName,
@@ -74,7 +76,7 @@ export const CardView: FC<CardViewProps> = ({
   const isWebsite = blockType === 'link'
   const isFile = blockType === 'attachment' || blockType === 'image'
   const type = isFile ? 'file' : 'default'
-  const [actionOptions] = useActionOptions(isWebsite ? undefined : linkUrl)
+  const [actionOptions] = useActionOptions(isWebsite ? undefined : downloadUrl)
   const onClick = useCallback(() => window.open(linkUrl, '_blank'), [linkUrl])
 
   return (

--- a/packages/legacy-editor/src/components/blockViews/EmbedView/embedViews/ImageView/ImageView.tsx
+++ b/packages/legacy-editor/src/components/blockViews/EmbedView/embedViews/ImageView/ImageView.tsx
@@ -22,6 +22,7 @@ import { useEditorContext } from '../../../../../hooks'
 export interface ImageViewProps {
   displayName: string
   url: string
+  downloadUrl: string
   height?: number | null
   width?: number | null
   align?: EmbedAttributes['image']['align']

--- a/packages/legacy-editor/src/components/blockViews/EmbedView/embedViews/ImageView/useImageState.ts
+++ b/packages/legacy-editor/src/components/blockViews/EmbedView/embedViews/ImageView/useImageState.ts
@@ -7,7 +7,7 @@ import { ImageViewProps } from './ImageView'
 import { maxWidth, minWidth } from './ImageView.style'
 import { useResizable } from './useResizable'
 
-export function useImageState({ url, node, updateEmbedBlockAttributes, width }: ImageViewProps): {
+export function useImageState({ url, downloadUrl, node, updateEmbedBlockAttributes, width }: ImageViewProps): {
   actionOptions: BlockActionOptions
   loaded: boolean
   showPreview: boolean
@@ -21,7 +21,7 @@ export function useImageState({ url, node, updateEmbedBlockAttributes, width }: 
   const { documentEditable } = useEditorContext()
   const [loaded, setLoaded] = useState(false)
   const [showPreview, setShowPreview] = useState(false)
-  const [actionOptions] = useActionOptions(url)
+  const [actionOptions] = useActionOptions(downloadUrl)
 
   const previewImage = useCallback((): void => {
     if (!node.attrs.image?.key || !loaded || showPreview) return

--- a/packages/legacy-editor/src/components/blockViews/EmbedView/embedViews/PreviewView/PreviewView.tsx
+++ b/packages/legacy-editor/src/components/blockViews/EmbedView/embedViews/PreviewView/PreviewView.tsx
@@ -21,6 +21,7 @@ export interface PreviewViewProps {
   fileName: string
   fileType: FileType
   fileUrl: string
+  downloadUrl: string
   icon?: string | null
   iframeUrl?: string | null
 }
@@ -45,13 +46,14 @@ export const PreviewView: FC<PreviewViewProps> = ({
   fileName,
   fileType,
   fileUrl,
+  downloadUrl,
   iframeUrl,
   icon,
   node,
   extension
 }) => {
   const isWebsite = fileType === 'html'
-  const [actionOptions] = useActionOptions(isWebsite ? undefined : fileUrl)
+  const [actionOptions] = useActionOptions(isWebsite ? undefined : downloadUrl)
 
   return (
     <BlockContainer

--- a/packages/legacy-editor/src/extensions/blocks/embed/meta.ts
+++ b/packages/legacy-editor/src/extensions/blocks/embed/meta.ts
@@ -28,7 +28,7 @@ export interface UrlData {
 }
 
 export interface EmbedOptions {
-  getFileUrl?: (key: string, source: 'EXTERNAL' | 'ORIGIN') => string | undefined | null
+  getFileUrl?: (key: string, source: 'EXTERNAL' | 'ORIGIN') => { url: string; downloadUrl: string } | undefined
   getGalleryImages?: (options: {
     query?: string
     page: number
@@ -74,6 +74,7 @@ export interface EmbedAttributes {
     name?: string
     key?: string
     viewUrl?: string
+    downloadUrl?: string
     displayName?: string | null
     source?: 'EXTERNAL' | 'ORIGIN'
     mode?: EmbedViewMode
@@ -88,6 +89,7 @@ export interface EmbedAttributes {
     displayName?: string | null
     key?: string
     viewUrl?: string
+    downloadUrl?: string
     contentType?: string | null
     type: 'ATTACHMENT'
     source?: 'EXTERNAL' | 'ORIGIN'


### PR DESCRIPTION
* ref: #94 
* fix: #300

1. Introduce `rack-cors` in development environment to fix `CORS` error.
2. Remove `current_pod` dependency in `create_direct_upload`
3. add `downloadUrl` field to download directly when click download.