### PR TITLE
fix(legacy-editor): only trigger multiple node selection by left-click mousedown

### DIFF
--- a/packages/legacy-editor/src/extensions/extensions/selection/__tests__/domEvents.test.ts
+++ b/packages/legacy-editor/src/extensions/extensions/selection/__tests__/domEvents.test.ts
@@ -10,6 +10,7 @@ describe('DomEvents', () => {
     const domEvents = new MultipleNodeSelectionDomEvents(editor, {})
 
     const event: Partial<MouseEvent> = {
+      button: 0,
       clientX: x,
       clientY: y
     }

--- a/packages/legacy-editor/src/extensions/extensions/selection/domEvents.ts
+++ b/packages/legacy-editor/src/extensions/extensions/selection/domEvents.ts
@@ -91,6 +91,9 @@ export class MultipleNodeSelectionDomEvents {
   }
 
   public mousedown(view: EditorView, event: MouseEvent): boolean {
+    // 0 represent for left-click, only accept left-lick case.
+    if (event.button !== 0) return false
+
     this.container.mouseSelection = {
       ...this.container.mouseSelection,
       anchor: {


### PR DESCRIPTION
fix #250