### PR TITLE
fix(formula): spreadsheet deadlock

### DIFF
--- a/packages/formula/src/__tests__/errorParse.test.ts
+++ b/packages/formula/src/__tests__/errorParse.test.ts
@@ -14,8 +14,8 @@ describe('errorParse', () => {
 
   it.each(testCases.errorTestCases)('$jestTitle', async args => {
     const parseResult = ctx.parseDirectly(args)
-    expect(parseResult.success).toBe(false)
-    expect([parseResult.errorMessages[0], parseResult.variableParseResult.valid]).toStrictEqual([
+    expect([parseResult.success, parseResult.errorMessages[0], parseResult.variableParseResult.valid]).toStrictEqual([
+      false,
       { type: args.errorType, message: args.errorMessage },
       args.valid ?? true
     ])

--- a/packages/formula/src/context/variable.ts
+++ b/packages/formula/src/context/variable.ts
@@ -381,7 +381,7 @@ export class VariableClass implements VariableInterface {
     level: number,
     input?: FormulaDefinition
   ): Promise<void> {
-    // console.debug(
+    // console.log(
     //   `reparse: ${sourceUuid && this.currentUUID === sourceUuid}`,
     //   { sourceUuid, id: this.id },
     //   this.t.meta.name,
@@ -418,6 +418,16 @@ export class VariableClass implements VariableInterface {
     }
 
     const parseResult = parse(ctx)
+    if (parseResult.errorMessages[0]?.type === 'circular_dependency') {
+      if (
+        !this.t.task.async &&
+        this.t.task.variableValue.result.type === 'Error' &&
+        this.t.task.variableValue.result.result.type === 'circular_dependency'
+      ) {
+        // Skip circular dependency
+        return
+      }
+    }
     const tempT = await interpret({ variable: this, ctx, parseResult })
     await this.cleanup()
     this.t = tempT

--- a/packages/formula/src/controls/block.ts
+++ b/packages/formula/src/controls/block.ts
@@ -154,7 +154,7 @@ export class BlockClass implements BlockType {
 
     const firstArgumentType = fetchResult(variable.t).type
 
-    parseTrackVariable(visitor, variable, this.id)
+    parseTrackVariable(visitor, variable)
 
     let finalCodeFragments = codeFragments
 

--- a/packages/formula/src/controls/column.ts
+++ b/packages/formula/src/controls/column.ts
@@ -14,6 +14,7 @@ import {
 import { codeFragments2definition, CodeFragmentVisitor, FormulaInterpreter } from '../grammar'
 import { CellClass } from '.'
 import { SpreadsheetReloadViaId, SpreadsheetUpdateNamePayload } from '../events'
+import { parseTrackCell } from '../grammar/dependency'
 
 export class ColumnClass implements ColumnType {
   columnId: ColumnId
@@ -166,6 +167,7 @@ export class ColumnClass implements ColumnType {
     }
 
     const cell = result.result
+    parseTrackCell(visitor, cell)
     if (visitor.ctx.meta.richType.type === 'spreadsheet') {
       const { spreadsheetId, rowId, columnId } = visitor.ctx.meta.richType.meta
       if (spreadsheetId === this.spreadsheetId && rowId === cell.rowId && columnId === cell.columnId) {

--- a/packages/formula/src/controls/row.ts
+++ b/packages/formula/src/controls/row.ts
@@ -1,5 +1,6 @@
 import { SpreadsheetReloadViaId, SpreadsheetUpdateNamePayload } from '../events'
 import { CodeFragmentVisitor, FormulaInterpreter } from '../grammar'
+import { parseTrackCell } from '../grammar/dependency'
 import {
   AnyTypeResult,
   CodeFragment,
@@ -129,6 +130,7 @@ export class RowClass implements RowType {
     }
 
     const errors: ErrorMessage[] = []
+    parseTrackCell(visitor, cell)
 
     if (visitor.ctx.meta.richType.type === 'spreadsheet') {
       const { spreadsheetId, rowId, columnId } = visitor.ctx.meta.richType.meta

--- a/packages/formula/src/controls/spreadsheet.ts
+++ b/packages/formula/src/controls/spreadsheet.ts
@@ -139,7 +139,6 @@ export class SpreadsheetClass implements SpreadsheetType {
         const changedColumnIds = [
           ...new Set([...Object.values(pairs1), ...Object.values(pairs2)].flatMap(p => [p.columnId, p.displayIndex]))
         ]
-        console.log('SpreadsheetUpdateColumnsViaId', this._columns, e.payload.columns, changedColumnIds)
 
         if (!changedColumnIds.length) return
 

--- a/packages/formula/src/controls/spreadsheet.ts
+++ b/packages/formula/src/controls/spreadsheet.ts
@@ -139,6 +139,8 @@ export class SpreadsheetClass implements SpreadsheetType {
         const changedColumnIds = [
           ...new Set([...Object.values(pairs1), ...Object.values(pairs2)].flatMap(p => [p.columnId, p.displayIndex]))
         ]
+        console.log('SpreadsheetUpdateColumnsViaId', this._columns, e.payload.columns, changedColumnIds)
+
         if (!changedColumnIds.length) return
 
         const result = MashcardEventBus.dispatch(

--- a/packages/formula/src/grammar/dependency.ts
+++ b/packages/formula/src/grammar/dependency.ts
@@ -66,7 +66,6 @@ export const parseTrackColumn = (visitor: Visitor, column: ColumnType): void => 
 
 export const parseTrackCell = (visitor: Visitor, cell: Cell): void => {
   const variable = visitor.ctx.formulaContext.findVariableById(cell.namespaceId, cell.variableId)
-  console.log('parseTrackCell', cell, variable)
   if (variable) {
     parseTrackVariable(visitor, variable)
   } else {

--- a/packages/formula/src/grammar/dependency.ts
+++ b/packages/formula/src/grammar/dependency.ts
@@ -1,5 +1,5 @@
 import { EventType } from '@mashcard/schema'
-import { BlockType, ColumnType, SpreadsheetType } from '../controls'
+import { BlockType, Cell, ColumnType, SpreadsheetType } from '../controls'
 import { SpreadsheetUpdateNameViaId, SpreadsheetReloadViaId, SpreadsheetUpdateNamePayload } from '../events'
 import { EventDependency, VariableInterface } from '../type'
 import { CodeFragmentVisitor } from './codeFragment'
@@ -64,10 +64,20 @@ export const parseTrackColumn = (visitor: Visitor, column: ColumnType): void => 
   visitor.eventDependencies.push(column.eventDependency({}))
 }
 
+export const parseTrackCell = (visitor: Visitor, cell: Cell): void => {
+  const variable = visitor.ctx.formulaContext.findVariableById(cell.namespaceId, cell.variableId)
+  console.log('parseTrackCell', cell, variable)
+  if (variable) {
+    parseTrackVariable(visitor, variable)
+  } else {
+    visitor.variableDependencies.push({ namespaceId: cell.namespaceId, variableId: cell.variableId })
+  }
+}
+
 /**
  * Track variableDependencies and flattenVariableDependencies when parse variable
  */
-export const parseTrackVariable = (visitor: Visitor, variable: VariableInterface, namespaceId: string): void => {
+export const parseTrackVariable = (visitor: Visitor, variable: VariableInterface): void => {
   if (variable.t.variableParseResult.async) {
     visitor.async = true
   }
@@ -80,10 +90,11 @@ export const parseTrackVariable = (visitor: Visitor, variable: VariableInterface
   if (!variable.t.variableParseResult.pure) {
     visitor.pure = false
   }
+  const { namespaceId, variableId } = variable.t.meta
 
-  visitor.variableDependencies.push({ namespaceId, variableId: variable.t.meta.variableId })
+  visitor.variableDependencies.push({ namespaceId, variableId })
   visitor.flattenVariableDependencies.push(...variable.t.variableParseResult.flattenVariableDependencies, {
     namespaceId,
-    variableId: variable.t.meta.variableId
+    variableId
   })
 }

--- a/packages/formula/src/grammar/operations/name.ts
+++ b/packages/formula/src/grammar/operations/name.ts
@@ -198,7 +198,7 @@ export const nameOperator: OperatorType = {
       { definition: '=A', errorMessage: '"A" not found', errorType: 'syntax', namespaceId },
       {
         definition: '=A.1',
-        errorMessage: 'errors.interpret.circular_dependency.spreadsheet',
+        errorMessage: 'errors.parse.circular_dependency.spreadsheet',
         errorType: 'circular_dependency',
         richType,
         namespaceId

--- a/packages/formula/src/grammar/operations/name.ts
+++ b/packages/formula/src/grammar/operations/name.ts
@@ -129,7 +129,7 @@ export const nameOperator: OperatorType = {
           type: 'Column'
         }
       case 'Variable':
-        parseTrackVariable(cstVisitor, result, cstVisitor.ctx.meta.namespaceId)
+        parseTrackVariable(cstVisitor, result)
         return {
           codeFragments: [variable2codeFragment(result, cstVisitor.ctx.meta.namespaceId)],
           image,

--- a/packages/formula/src/grammar/operations/thisRecord.ts
+++ b/packages/formula/src/grammar/operations/thisRecord.ts
@@ -139,8 +139,7 @@ export const thisRecordOperator: OperatorType = {
       {
         definition: `=ThisRecord.A.1`,
         errorType: 'circular_dependency',
-        groupOptions: [{ name: 'basicError' }],
-        errorMessage: 'errors.interpret.circular_dependency.spreadsheet',
+        errorMessage: 'errors.parse.circular_dependency.spreadsheet',
         richType,
         namespaceId
       },

--- a/packages/formula/src/tests/feature/event/index.ts
+++ b/packages/formula/src/tests/feature/event/index.ts
@@ -2,6 +2,7 @@ import { TestCaseInterface, TestCaseName } from '../../testType'
 import { BlockEventTestCase } from './blockEvent'
 import { ColumnEventTestCase } from './columnEvent'
 import { RowEventTestCase } from './rowEvent'
+import { SpreadsheetDeadlockEventTestCase } from './spreadsheetDeadlockEvent'
 import { SpreadsheetEventTestCase } from './spreadsheetEvent'
 import { VariableEventTestCase } from './variableEvent'
 
@@ -10,7 +11,8 @@ export const EventTestCases: TestCaseInterface[] = [
   SpreadsheetEventTestCase,
   VariableEventTestCase,
   ColumnEventTestCase,
-  RowEventTestCase
+  RowEventTestCase,
+  SpreadsheetDeadlockEventTestCase
 ]
 
 export const EventNames: TestCaseName[] = EventTestCases.map(c => c.name)

--- a/packages/formula/src/tests/feature/event/spreadsheetDeadlockEvent.ts
+++ b/packages/formula/src/tests/feature/event/spreadsheetDeadlockEvent.ts
@@ -1,0 +1,299 @@
+import { Cell, Column, Row } from '../../../controls'
+import { generateUUIDs } from '../../testHelper'
+import { mockCell } from '../../testMock'
+import { DistributeEvents, SpreadsheetInput, TestCaseInterface } from '../../testType'
+
+const [
+  namespaceId,
+  spreadsheetId,
+  column1Id,
+  column2Id,
+  column3Id,
+  row1Id,
+  row2Id,
+  row3Id,
+  CELL_A1_ID,
+  CELL_B1_ID,
+  CELL_C1_ID,
+  CELL_A2_ID,
+  CELL_A3_ID,
+  newColumnId,
+  newRowId,
+  cellxId,
+  cellyId,
+  variablexId,
+  variableyId
+] = generateUUIDs()
+
+const A1CellRichType = {
+  type: 'spreadsheet',
+  meta: { spreadsheetId, columnId: column1Id, rowId: row1Id }
+} as const
+
+const B1CellRichType = {
+  type: 'spreadsheet',
+  meta: { spreadsheetId, columnId: column2Id, rowId: row1Id }
+} as const
+
+const A2CellRichType = {
+  type: 'spreadsheet',
+  meta: { spreadsheetId, columnId: column1Id, rowId: row2Id }
+} as const
+
+const PARSE_ERROR = {
+  message: 'errors.parse.circular_dependency.spreadsheet',
+  type: 'circular_dependency'
+} as const
+
+const INTERPRET_ERROR = {
+  message: 'errors.interpret.circular_dependency.spreadsheet',
+  type: 'circular_dependency'
+} as const
+
+const [column1, column2, column3]: Column[] = [
+  {
+    spreadsheetId,
+    name: 'first',
+    columnId: column1Id,
+    title: 'first',
+    displayIndex: 'A',
+    index: 0,
+    sort: 0
+  },
+  {
+    spreadsheetId,
+    name: 'second',
+    columnId: column2Id,
+    title: 'second',
+    displayIndex: 'B',
+    index: 1,
+    sort: 1
+  },
+  {
+    spreadsheetId,
+    name: 'third',
+    columnId: column3Id,
+    title: 'third',
+    displayIndex: 'C',
+    index: 2,
+    sort: 2
+  }
+]
+
+const [row1, row2, row3]: Row[] = [
+  { spreadsheetId, rowId: row1Id, rowIndex: 0 },
+  { spreadsheetId, rowId: row2Id, rowIndex: 1 },
+  { spreadsheetId, rowId: row3Id, rowIndex: 2 }
+]
+
+const columnNew: Pick<Column, 'spreadsheetId' | 'name' | 'title' | 'columnId' | 'sort'> = {
+  spreadsheetId,
+  name: 'second',
+  columnId: newColumnId,
+  title: 'second',
+  sort: 1
+}
+
+const rowNew: Pick<Row, 'spreadsheetId' | 'rowId'> = {
+  spreadsheetId,
+  rowId: newRowId
+}
+
+const CELLS_MAP: Record<`${string},${string}`, Pick<Cell, 'value' | 'variableId' | 'cellId'>> = {
+  [`${newColumnId},${row1Id}`]: {
+    cellId: cellxId,
+    variableId: variablexId,
+    value: 'newColumnCell'
+  },
+  [`${column1Id},${newRowId}`]: {
+    cellId: cellyId,
+    variableId: variableyId,
+    value: 'newRowCell'
+  }
+}
+
+const prependColumnEvent: DistributeEvents = [
+  'columnChange',
+  {
+    spreadsheetId,
+    namespaceId,
+    columns: [
+      { ...columnNew, displayIndex: 'A', index: 0 },
+      { ...column1, displayIndex: 'B', index: 1 },
+      { ...column2, displayIndex: 'C', index: 2 },
+      { ...column3, displayIndex: 'D', index: 3 }
+    ]
+  }
+]
+
+const deleteFirstColumnEvent: DistributeEvents = [
+  'columnChange',
+  {
+    spreadsheetId,
+    namespaceId,
+    columns: [
+      { ...column2, index: 0, displayIndex: 'A' },
+      { ...column3, index: 1, displayIndex: 'B' }
+    ]
+  }
+]
+
+const prependRowEvent: DistributeEvents = [
+  'rowChange',
+  {
+    spreadsheetId,
+    namespaceId,
+    rows: [
+      { ...rowNew, rowIndex: 0 },
+      { ...row1, rowIndex: 1 },
+      { ...row2, rowIndex: 2 },
+      { ...row3, rowIndex: 3 }
+    ]
+  }
+]
+
+const deleteFirstRowEvent: DistributeEvents = [
+  'rowChange',
+  {
+    spreadsheetId,
+    namespaceId,
+    rows: [
+      { ...row2, rowIndex: 0 },
+      { ...row3, rowIndex: 1 }
+    ]
+  }
+]
+
+const definitionCases: (column: string, row: string) => Array<{ definition: string; logicRow?: true; error: any }> = (
+  column,
+  row
+) => [
+  { definition: `=${column}.${row}`, error: PARSE_ERROR },
+  { definition: `=spreadsheet1.${column}.${row}`, error: PARSE_ERROR },
+  { definition: `=ThisRecord.${column}.${row}`, error: PARSE_ERROR },
+  { definition: `=ThisRow.${column}`, logicRow: true, error: PARSE_ERROR },
+
+  { definition: `=${column}[${row}]`, error: INTERPRET_ERROR },
+  { definition: `=spreadsheet1.${column}[${row}]`, error: INTERPRET_ERROR },
+  { definition: `=ThisRecord.${column}[${row}]`, error: INTERPRET_ERROR },
+  { definition: `=spreadsheet1["${column}"][${row}]`, error: INTERPRET_ERROR },
+  { definition: `=ThisRecord["${column}"][${row}]`, error: INTERPRET_ERROR },
+  { definition: `=ThisRow["${column}"]`, logicRow: true, error: INTERPRET_ERROR }
+]
+
+export const SpreadsheetDeadlockEventTestCase: TestCaseInterface = {
+  name: 'spreadsheetDeadlockEvent',
+  testCases: {
+    pages: [
+      {
+        pageName: 'SpreadsheetDeadLockEventPage1',
+        pageId: namespaceId,
+        spreadsheets: [
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          <SpreadsheetInput<3, 3>>{
+            getCell: ({ columnId, rowId, rowIndex, columnIndex }) => {
+              const cell = CELLS_MAP[`${columnId},${rowId}`]
+              if (!cell) return null!
+              return { ...cell, rowIndex, columnIndex, columnId, rowId, spreadsheetId, namespaceId }
+            },
+            name: 'spreadsheet1',
+            spreadsheetId,
+            columns: [
+              {
+                ...column1,
+                cells: [
+                  { value: '1', cellId: CELL_A1_ID },
+                  { value: '3', cellId: CELL_A2_ID },
+                  { value: '5', cellId: CELL_A3_ID }
+                ]
+              },
+              { ...column2, cells: [{ value: '2', cellId: CELL_B1_ID }, { value: '4' }, { value: '6' }] },
+              { ...column3, cells: [{ value: '3', cellId: CELL_C1_ID }, { value: '5' }, { value: '7' }] }
+            ],
+            rows: [row1, row2, row3]
+          }
+        ]
+      }
+    ],
+    eventTestCases: [
+      ...definitionCases('A', '1').flatMap<NonNullable<TestCaseInterface['testCases']['eventTestCases']>[0]>(a => [
+        {
+          label: '[cell A.1] [prepend column] deadlock to normal',
+          namespaceId,
+          richType: A1CellRichType,
+          resultBefore: a.error,
+          resultAfter: mockCell('newColumnCell', cellxId, 'A', a.logicRow ? row1Id : '1'),
+          events: [prependColumnEvent],
+          ...a
+        },
+        {
+          label: '[cell B.1] [delete column] normal to deadlock',
+          namespaceId,
+          richType: B1CellRichType,
+          resultBefore: mockCell('1', CELL_A1_ID, 'A', a.logicRow ? row1Id : '1'),
+          resultAfter: a.error,
+          events: [deleteFirstColumnEvent],
+          ...a
+        },
+        {
+          label: '[cell A.1] [prepend row] deadlock to normal',
+          namespaceId,
+          richType: A1CellRichType,
+          resultBefore: a.error,
+          resultAfter: a.logicRow ? a.error : mockCell('newRowCell', cellyId, 'A', '1'),
+          events: [prependRowEvent],
+          ...a
+        },
+        {
+          label: '[cell A.2] [delete row] normal to deadlock',
+          namespaceId,
+          richType: A2CellRichType,
+          resultBefore: a.logicRow ? a.error : mockCell('1', CELL_A1_ID, 'A', '1'),
+          resultAfter: a.error,
+          events: [deleteFirstRowEvent],
+          ...a
+        }
+      ]),
+      ...definitionCases('B', '1').flatMap<NonNullable<TestCaseInterface['testCases']['eventTestCases']>[0]>(a => [
+        {
+          label: '[cell A.1] [prepend column] normal to deadlock',
+          namespaceId,
+          richType: A1CellRichType,
+          resultBefore: mockCell('2', CELL_B1_ID, 'B', a.logicRow ? row1Id : '1'),
+          resultAfter: a.error,
+          events: [prependColumnEvent],
+          ...a
+        },
+        {
+          label: '[cell B.1] [delete column] deadlock to normal',
+          namespaceId,
+          richType: B1CellRichType,
+          resultBefore: a.error,
+          resultAfter: mockCell('3', CELL_C1_ID, 'B', a.logicRow ? row1Id : '1'),
+          events: [deleteFirstColumnEvent],
+          ...a
+        }
+      ]),
+      ...definitionCases('A', '2').flatMap<NonNullable<TestCaseInterface['testCases']['eventTestCases']>[0]>(a => [
+        {
+          label: '[cell A.1] [prepend row] normal to deadlock',
+          namespaceId,
+          richType: A1CellRichType,
+          resultBefore: a.logicRow ? a.error : mockCell('3', CELL_A2_ID, 'A', '2'),
+          resultAfter: a.error,
+          events: [prependRowEvent],
+          ...a
+        },
+        {
+          label: '[cell A.2] [delete row] deadlock to normal',
+          namespaceId,
+          richType: A2CellRichType,
+          resultBefore: a.error,
+          resultAfter: a.logicRow ? a.error : mockCell('5', CELL_A3_ID, 'A', '2'),
+          events: [deleteFirstRowEvent],
+          ...a
+        }
+      ])
+    ]
+  }
+}

--- a/packages/formula/src/tests/feature/index.ts
+++ b/packages/formula/src/tests/feature/index.ts
@@ -11,10 +11,12 @@ import { EventTestCases } from './event'
 import { CompleteTestCase } from './complete'
 import { FormatTestCase } from './format'
 import { BasicTestCase } from './basic'
+import { SpreadsheetVariableTestCase } from './spreadsheetVariable'
 
 export const FeatureTestCases: TestCaseInterface[] = [
   FunctionCallTestCase,
   VariableTestCase,
+  SpreadsheetVariableTestCase,
   PowerFxTestCase,
   SpreadsheetTestCase,
   ParserTestCase,

--- a/packages/formula/src/tests/feature/spreadsheetVariable.ts
+++ b/packages/formula/src/tests/feature/spreadsheetVariable.ts
@@ -1,7 +1,7 @@
 import { generateUUIDs } from '../testHelper'
 import { SpreadsheetInput, TestCaseInterface } from '../testType'
 
-const [namespaceId, spreadsheetId, column1Id, row1Id, cellA1VariableId, cellA2VariableId] = generateUUIDs()
+const [namespaceId, spreadsheetId, column1Id, row1Id, variableId] = generateUUIDs()
 
 const A1CellRichType = {
   type: 'spreadsheet',
@@ -15,7 +15,13 @@ export const SpreadsheetVariableTestCase: TestCaseInterface = {
       {
         pageName: 'SpreadsheetVariablePage',
         pageId: namespaceId,
-        // variables: [{ variableName: 'num0', definition: '=0', variableId: num0Id }],
+        variables: [
+          {
+            variableName: 'num0',
+            definition: '=spreadsheet.second.1',
+            insertOptions: { ignoreParseError: true, ignoreSyntaxError: true }
+          }
+        ],
         spreadsheets: [
           // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           <SpreadsheetInput<2, 2>>{
@@ -26,15 +32,12 @@ export const SpreadsheetVariableTestCase: TestCaseInterface = {
                 name: 'first',
                 displayIndex: 'A',
                 columnId: column1Id,
-                cells: [
-                  { value: '1', variableId: cellA1VariableId },
-                  { value: '=A.1', variableId: cellA2VariableId }
-                ]
+                cells: [{ value: '1', variableId }, { value: '=A.1' }]
               },
               {
                 name: 'second',
                 displayIndex: 'B',
-                cells: [{ value: '2' }, { value: '4' }]
+                cells: [{ value: '=A.2' }, { value: '=B.1' }]
               }
             ],
             rows: [{ rowId: row1Id }, {}]
@@ -43,13 +46,18 @@ export const SpreadsheetVariableTestCase: TestCaseInterface = {
       }
     ],
     errorTestCases: [
-      {
-        definition: `=A.2`,
-        errorType: 'deps',
+      ...[
+        { definition: `=A.2` },
+        { definition: `=B.2`, label: 'flattenVariableDependencies' },
+        { definition: '=num0', label: 'normal variable flatten ok' }
+      ].map<NonNullable<TestCaseInterface['testCases']['errorTestCases']>[0]>(t => ({
         namespaceId,
+        variableId,
         richType: A1CellRichType,
-        errorMessage: `Column "Z" not found`
-      }
+        errorType: 'circular_dependency',
+        errorMessage: 'errors.parse.circular_dependency.variable',
+        ...t
+      }))
     ]
   }
 }

--- a/packages/formula/src/tests/feature/spreadsheetVariable.ts
+++ b/packages/formula/src/tests/feature/spreadsheetVariable.ts
@@ -1,0 +1,55 @@
+import { generateUUIDs } from '../testHelper'
+import { SpreadsheetInput, TestCaseInterface } from '../testType'
+
+const [namespaceId, spreadsheetId, column1Id, row1Id, cellA1VariableId, cellA2VariableId] = generateUUIDs()
+
+const A1CellRichType = {
+  type: 'spreadsheet',
+  meta: { spreadsheetId, columnId: column1Id, rowId: row1Id }
+} as const
+
+export const SpreadsheetVariableTestCase: TestCaseInterface = {
+  name: 'variable',
+  testCases: {
+    pages: [
+      {
+        pageName: 'SpreadsheetVariablePage',
+        pageId: namespaceId,
+        // variables: [{ variableName: 'num0', definition: '=0', variableId: num0Id }],
+        spreadsheets: [
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          <SpreadsheetInput<2, 2>>{
+            name: 'spreadsheet',
+            spreadsheetId,
+            columns: [
+              {
+                name: 'first',
+                displayIndex: 'A',
+                columnId: column1Id,
+                cells: [
+                  { value: '1', variableId: cellA1VariableId },
+                  { value: '=A.1', variableId: cellA2VariableId }
+                ]
+              },
+              {
+                name: 'second',
+                displayIndex: 'B',
+                cells: [{ value: '2' }, { value: '4' }]
+              }
+            ],
+            rows: [{ rowId: row1Id }, {}]
+          }
+        ]
+      }
+    ],
+    errorTestCases: [
+      {
+        definition: `=A.2`,
+        errorType: 'deps',
+        namespaceId,
+        richType: A1CellRichType,
+        errorMessage: `Column "Z" not found`
+      }
+    ]
+  }
+}

--- a/packages/formula/src/tests/testHelper.ts
+++ b/packages/formula/src/tests/testHelper.ts
@@ -74,7 +74,7 @@ const buildSpreadsheet = (
   oldState: UUIDState,
   namespaceId: string,
   formulaContext: ContextInterface,
-  { spreadsheetId: oldSpreadsheetId, name, rows, columns }: SpreadsheetInput<number, number>
+  { spreadsheetId: oldSpreadsheetId, name, rows, columns, getCell }: SpreadsheetInput<number, number>
 ): [SpreadsheetType, UUIDState] => {
   let uuidState = oldState
   const [spreadsheetId, state] = getUuid(oldSpreadsheetId, uuidState)
@@ -89,7 +89,7 @@ const buildSpreadsheet = (
         namespaceId,
         columns: [],
         rows: [],
-        getCell: ({ rowId, columnId }) => null!
+        getCell: args => getCell?.(args) ?? null!
       }),
       uuidState
     ]
@@ -119,7 +119,7 @@ const buildSpreadsheet = (
         namespaceId,
         columns: columnResult,
         rows: [],
-        getCell: ({ rowId, columnId }) => null!
+        getCell: args => getCell?.(args) ?? null!
       }),
       uuidState
     ]
@@ -161,7 +161,8 @@ const buildSpreadsheet = (
       namespaceId,
       columns: columnResult,
       rows: rowResult,
-      getCell: ({ rowId, columnId }) => cells.find(cell => cell.rowId === rowId && cell.columnId === columnId)!
+      getCell: args =>
+        cells.find(cell => cell.rowId === args.rowId && cell.columnId === args.columnId) ?? getCell?.(args) ?? null!
     }),
     uuidState
   ]

--- a/packages/formula/src/tests/testType.ts
+++ b/packages/formula/src/tests/testType.ts
@@ -1,7 +1,7 @@
 import { FixedLengthTuple, RequireField } from '@mashcard/active-support'
 import { EventType } from '@mashcard/schema'
 import { FormulaContextArgs } from '../context'
-import { Cell } from '../controls'
+import { Cell, SpreadsheetInitializer } from '../controls'
 import { OperatorName, ParseResult } from '../grammar'
 import {
   CodeFragment,
@@ -75,6 +75,7 @@ export interface SpreadsheetInput<ColumnCount extends number, RowCount extends n
   name: string
   columns: FixedLengthTuple<ColumnInput<RowCount>, ColumnCount>
   rows?: FixedLengthTuple<RowInput, RowCount>
+  getCell?: SpreadsheetInitializer['getCell']
 }
 export interface PageInput {
   pageId?: MockedUUIDV4
@@ -102,6 +103,7 @@ type FeatureName =
   | 'blockEvent'
   | 'variableEvent'
   | 'spreadsheetEvent'
+  | 'spreadsheetDeadlockEvent'
   | 'columnEvent'
   | 'rowEvent'
 type FeatureTestName = 'cst'

--- a/packages/legacy-editor/__snapshots__/components/blockViews/FormulaView/__tests__/formulaType.test.tsx.snap
+++ b/packages/legacy-editor/__snapshots__/components/blockViews/FormulaView/__tests__/formulaType.test.tsx.snap
@@ -913,7 +913,7 @@ exports[`formulaType [cell] basic "=BasicPage.spreadsheet.first.1" 2`] = `
           class="mashcard-formula-mark"
           data-code="NumberLiteral"
           data-display="1"
-          data-errors="\\"errors.interpret.circular_dependency.spreadsheet\\""
+          data-errors="\\"errors.parse.circular_dependency.spreadsheet\\""
           data-index="7"
           data-type="number"
           style="color: #39b3e8;; 

--- a/packages/legacy-editor/__snapshots__/components/ui/Formula/__tests__/FormulaDisplay.test.tsx.snap
+++ b/packages/legacy-editor/__snapshots__/components/ui/Formula/__tests__/FormulaDisplay.test.tsx.snap
@@ -461,7 +461,7 @@ exports[`FormulaDisplay [cell] basic "=BasicPage.spreadsheet.first.1" 2`] = `
       class="mashcard-formula-borderless"
       style="color: rgb(207, 31, 40);"
     >
-      #&lt;Error&gt; errors.interpret.circular_dependency.spreadsheet
+      #&lt;Error&gt; errors.parse.circular_dependency.spreadsheet
     </span>
   </span>
 </div>

--- a/packages/legacy-editor/__snapshots__/components/ui/Formula/__tests__/FormulaResult.test.tsx.snap
+++ b/packages/legacy-editor/__snapshots__/components/ui/Formula/__tests__/FormulaResult.test.tsx.snap
@@ -867,7 +867,7 @@ exports[`FormulaResult [cell] basic "=BasicPage.spreadsheet.first.1" 2`] = `
       <span
         class="formula-result-error-message"
       >
-        errors.interpret.circular_dependency.spreadsheet
+        errors.parse.circular_dependency.spreadsheet
       </span>
     </span>
   </div>
@@ -2852,29 +2852,6 @@ exports[`FormulaResult thisRecord "=ThisRecord" -> [syntax] "errors.parse.unavai
         class="formula-result-error-message"
       >
         errors.parse.unavailable.thisRecord
-      </span>
-    </span>
-  </div>
-</div>
-`;
-
-exports[`FormulaResult thisRecord "=ThisRecord.A.1" -> [circular_dependency] "errors.interpret.circular_dependency.spreadsheet" 1`] = `
-<div>
-  <div
-    class="mc-c-cKFnpX"
-  >
-    <span
-      class="formula-result-error"
-    >
-      <span
-        class="formula-result-error-type"
-      >
-        circular_dependency
-      </span>
-      <span
-        class="formula-result-error-message"
-      >
-        errors.interpret.circular_dependency.spreadsheet
       </span>
     </span>
   </div>

--- a/packages/legacy-editor/__snapshots__/components/ui/Formula/__tests__/FormulaValue.test.tsx.snap
+++ b/packages/legacy-editor/__snapshots__/components/ui/Formula/__tests__/FormulaValue.test.tsx.snap
@@ -613,7 +613,7 @@ exports[`FormulaValue [cell] basic "=BasicPage.spreadsheet.first.1" 3`] = `
     class="mashcard-formula-borderless"
     style="color: rgb(207, 31, 40);"
   >
-    #&lt;Error&gt; errors.interpret.circular_dependency.spreadsheet
+    #&lt;Error&gt; errors.parse.circular_dependency.spreadsheet
   </span>
 </div>
 `;
@@ -624,7 +624,7 @@ exports[`FormulaValue [cell] basic "=BasicPage.spreadsheet.first.1" 4`] = `
     class="mashcard-formula-borderless"
     style="color: rgb(207, 31, 40);"
   >
-    #&lt;Error&gt; errors.interpret.circular_dependency.spreadsheet
+    #&lt;Error&gt; errors.parse.circular_dependency.spreadsheet
   </span>
 </div>
 `;

--- a/packages/legacy-editor/src/components/blockViews/Spreadsheet/useSpreadsheet.ts
+++ b/packages/legacy-editor/src/components/blockViews/Spreadsheet/useSpreadsheet.ts
@@ -255,6 +255,7 @@ export function useSpreadsheet(options: {
     (spreadsheetId: string, rowId: string, columnId: string): BlockInput => {
       let block = cellsMap.current.get(rowId)?.get(columnId)
       if (!block) {
+        // TODO: variable is not persisted cause circular dependency: A1: =A2 && A2: =A1
         // TODO: This should be refactored when we have formula state management.
         const formulaId =
           formulaContext?.findVariableByCellMeta({ spreadsheetId, columnId, rowId })?.t.meta.variableId ?? uuid()


### PR DESCRIPTION
* fix #453 

1. Fix deadlock caused by deleted column.
2. Fix deadlock caused by circular dependency.
3. Add more testCases.

```
A1: `=A.2`
A2: `=A.1`
```

or

```
A1: `=A.2`
A2: `=num1`
num1: `=A.1`
```

NOTE that there is still a BUG that if cell is not initialized, these cases can cause a deadlock.
I add a TODO message for this scene.

https://github.com/mashcard/mashcard/pull/458/files#diff-58761a092ff0f5d6bf7997ee740f8c81e2abfdbbe92745389b7dd7c7bb4ae652R258