### PR TITLE
Refactor react node view

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -26,5 +26,12 @@
     "lint:type": "run -T tsc",
     "test:jest": "run -T jest",
     "test:jest:fix": "run -T jest --silent -u"
+  },
+  "dependencies": {
+    "@mashcard/active-support": "workspace:^",
+    "prosemirror-model": "^1.18.1",
+    "prosemirror-state": "^1.4.1",
+    "prosemirror-transform": "^1.6.0",
+    "prosemirror-view": "^1.27.0"
   }
 }

--- a/packages/editor/src/ReactNodeVew/NodeViewContainer.tsx
+++ b/packages/editor/src/ReactNodeVew/NodeViewContainer.tsx
@@ -1,0 +1,25 @@
+import { createContext, FC, PropsWithChildren, RefObject, useContext, useEffect, useMemo, useRef } from 'react'
+
+export interface NodeViewContextProps {
+  setContentDOM?: (contentDOM: HTMLElement | null) => void
+}
+
+export const NodeViewContext = createContext<NodeViewContextProps>({})
+
+export function useNodeContent<T extends HTMLElement>(): RefObject<T> {
+  const { setContentDOM } = useContext(NodeViewContext)
+  const ref = useRef<T>(null)
+
+  useEffect(() => {
+    setContentDOM?.(ref.current)
+  }, [setContentDOM])
+
+  return ref
+}
+
+export interface NodeViewContainerProps extends PropsWithChildren, NodeViewContextProps {}
+
+export const NodeViewContainer: FC<NodeViewContainerProps> = ({ setContentDOM, children }) => {
+  const contextValue = useMemo<NodeViewContextProps>(() => ({ setContentDOM }), [setContentDOM])
+  return <NodeViewContext.Provider value={contextValue}>{children}</NodeViewContext.Provider>
+}

--- a/packages/editor/src/ReactNodeVew/ReactNodeView.tsx
+++ b/packages/editor/src/ReactNodeVew/ReactNodeView.tsx
@@ -1,0 +1,116 @@
+import { uuid } from '@mashcard/active-support'
+import { EditorView, NodeView } from 'prosemirror-view'
+import { ComponentType } from 'react'
+import { NodePortal } from '../NodePortal'
+import { flushSync } from 'react-dom'
+import { NodeViewContainer } from './NodeViewContainer'
+
+export { useNodeContent } from './NodeViewContainer'
+export { NodeViewContainer }
+
+/**
+ * The store for nodePortals mutation
+ */
+export interface NodePortalStore {
+  /**
+   * Adds or update node portal.
+   */
+  set: (nodePortal: NodePortal) => void
+  /**
+   * Removes a node portal by id.
+   */
+  remove: (id: string) => void
+}
+
+/**
+ * A Prosemirror NodeView rendering view by react component.
+ * @param component The react component for NodeView rendering.
+ * @param editorView The editor view of current Prosemirror editor state
+ * @param nodePortalStore The store for nodePortals mutation
+ * @param asContainer Define the tag of react portal container, optional argument.
+ */
+export class ReactNodeView<ComponentProps = {}> implements NodeView {
+  /**
+   * Unique id
+   */
+  public readonly id: string
+  /**
+   * The store for nodePortals mutation
+   */
+  public readonly nodePortalStore: NodePortalStore
+  /**
+   * The react component for NodeView rendering.
+   */
+  public readonly component: ComponentType<ComponentProps>
+  /**
+   * The dom container for NodeView
+   */
+  public readonly container: HTMLElement
+  /**
+   * The editor view of current Prosemirror editor state
+   */
+  public readonly editorView: EditorView
+
+  public contentDOM: HTMLElement | null
+  public dom: Element
+
+  constructor({
+    component,
+    componentProps,
+    editorView,
+    nodePortalStore,
+    asContainer
+  }: {
+    component: ComponentType<ComponentProps>
+    componentProps: ComponentProps
+    editorView: EditorView
+    nodePortalStore: NodePortalStore
+    asContainer?: keyof HTMLElementTagNameMap
+  }) {
+    this.editorView = editorView
+    this.container = document.createElement(asContainer ?? 'div')
+    this.contentDOM = document.createElement('div')
+
+    this.nodePortalStore = nodePortalStore
+    this.id = uuid()
+    this.component = component
+
+    // renders react component synchronously when NodeView created.
+    flushSync(() => {
+      this.renderComponent(componentProps)
+    })
+
+    this.dom = this.container
+  }
+
+  public destroy(): void {
+    this.nodePortalStore.remove(this.id)
+    this.contentDOM = null
+  }
+
+  /**
+   * Used to set current contentDOM. Set it via useRef in react component for example.
+   * @param contentDOM The DOM node that should hold the node's content.
+   */
+  protected readonly setContentDOM = (contentDOM: HTMLElement | null): void => {
+    if (contentDOM) {
+      contentDOM.append(...Array.from(this.contentDOM?.childNodes ?? []))
+    }
+    this.contentDOM = contentDOM
+  }
+
+  /**
+   * Renders the component for updating NodeView's view.
+   */
+  protected renderComponent(props: ComponentProps): void {
+    this.nodePortalStore.set({
+      id: this.id,
+      container: this.container,
+      child: (
+        <NodeViewContainer setContentDOM={this.setContentDOM}>
+          <this.component {...props} />
+        </NodeViewContainer>
+      )
+    })
+  }
+}

--- a/packages/editor/src/ReactNodeVew/__tests__/NodeViewContainer.test.tsx
+++ b/packages/editor/src/ReactNodeVew/__tests__/NodeViewContainer.test.tsx
@@ -1,0 +1,23 @@
+import { render } from '@testing-library/react'
+import { FC } from 'react'
+import { NodeViewContainer, useNodeContent } from '../NodeViewContainer'
+
+describe('NodeViewContainer', () => {
+  it('sets contentDOM correctly', () => {
+    const setContentDOM = jest.fn()
+
+    const TestComponent: FC = () => {
+      const ref = useNodeContent<HTMLDivElement>()
+
+      return <div ref={ref} />
+    }
+
+    render(
+      <NodeViewContainer setContentDOM={setContentDOM}>
+        <TestComponent />
+      </NodeViewContainer>
+    )
+
+    expect(setContentDOM).toBeCalled()
+  })
+})

--- a/packages/editor/src/ReactNodeVew/__tests__/ReactNodeView.test.tsx
+++ b/packages/editor/src/ReactNodeVew/__tests__/ReactNodeView.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react'
+import { FC, ReactElement, ReactNode } from 'react'
+import { NodePortalStore, ReactNodeView, useNodeContent } from '../ReactNodeView'
+
+describe('ReactNodeView', () => {
+  it('renders NodeView component correctly', () => {
+    const componentProps = {
+      text: 'text'
+    }
+    const component: FC<typeof componentProps> = props => <div>{props.text}</div>
+
+    let child: ReactNode
+
+    const nodePortalStore: NodePortalStore = {
+      set(portal) {
+        child = portal.child
+      },
+      remove: jest.fn()
+    }
+
+    // eslint-disable-next-line no-new
+    new ReactNodeView({
+      component,
+      componentProps,
+      editorView: {} as any,
+      nodePortalStore
+    })
+
+    render(child as ReactElement)
+
+    expect(screen.getByText(componentProps.text)).toBeInTheDocument()
+  })
+
+  it('renders NodeView component with NodeContent correctly', () => {
+    const Component: FC = () => {
+      const ref = useNodeContent<HTMLDivElement>()
+      return <div ref={ref} />
+    }
+
+    const text = 'text'
+
+    let child: ReactNode
+
+    const nodePortalStore: NodePortalStore = {
+      set(portal) {
+        child = portal.child
+      },
+      remove: jest.fn()
+    }
+
+    const nodeView = new ReactNodeView({
+      component: Component,
+      componentProps: {},
+      editorView: {} as any,
+      nodePortalStore
+    })
+
+    const textElement = document.createElement('span')
+    textElement.innerHTML = text
+    nodeView.contentDOM?.append(textElement)
+
+    render(child as ReactElement)
+
+    expect(screen.getByText(text)).toBeInTheDocument()
+  })
+
+  it('destroys NodeView correctly', () => {
+    const component: FC = () => <div />
+
+    const nodePortalStore: NodePortalStore = {
+      set: jest.fn(),
+      remove: jest.fn()
+    }
+
+    const nodeView = new ReactNodeView({
+      component,
+      componentProps: {},
+      editorView: {} as any,
+      nodePortalStore
+    })
+
+    nodeView.destroy()
+
+    expect(nodePortalStore.remove).toBeCalled()
+  })
+})

--- a/packages/editor/src/ReactNodeVew/index.ts
+++ b/packages/editor/src/ReactNodeVew/index.ts
@@ -1,0 +1,1 @@
+export * from './ReactNodeView'

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -1,2 +1,3 @@
 export * from './prosemirror'
 export * from './NodePortal'
+export * from './ReactNodeVew'

--- a/packages/legacy-editor/__snapshots__/components/blockViews/BlockquoteView/__tests__/Blockquote.test.tsx.snap
+++ b/packages/legacy-editor/__snapshots__/components/blockViews/BlockquoteView/__tests__/Blockquote.test.tsx.snap
@@ -7,11 +7,8 @@ exports[`BlockquoteView renders blockquote correctly 1`] = `
     style="white-space: normal; pointer-events: unset;"
   >
     <blockquote
-      as="blockquote"
       class="mc-c-fGUTRT"
-      data-node-view-content=""
       data-placeholder=""
-      style="white-space: pre-wrap;"
     />
   </div>
 </div>

--- a/packages/legacy-editor/__snapshots__/components/blockViews/CalloutView/__tests__/CalloutView.test.tsx.snap
+++ b/packages/legacy-editor/__snapshots__/components/blockViews/CalloutView/__tests__/CalloutView.test.tsx.snap
@@ -27,11 +27,8 @@ exports[`CalloutView renders CalloutView with emoji icon correctly 1`] = `
         </button>
       </div>
       <span
-        as="span"
         class="mc-c-hbPmqD"
-        data-node-view-content=""
         data-placeholder=""
-        style="white-space: pre-wrap;"
       />
     </div>
   </div>

--- a/packages/legacy-editor/__snapshots__/components/blockViews/CodeBlockView/__tests__/CodeBlockView.test.tsx.snap
+++ b/packages/legacy-editor/__snapshots__/components/blockViews/CodeBlockView/__tests__/CodeBlockView.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`CodeBlockView matches snapshot correctly 1`] = `
 <div>
   <div
-    class="mc-c-bxRahZ mc-c-eNvXfk"
+    class="mc-c-gSKecW mc-c-kMAtnc"
     data-node-view-wrapper=""
     style="white-space: normal; pointer-events: unset;"
   >
@@ -70,14 +70,11 @@ exports[`CodeBlockView matches snapshot correctly 1`] = `
       </div>
       <pre
         class="line-numbers language-javascript"
+        data-placeholder=""
         spellcheck="false"
       >
         <code
-          as="code"
           class="undefined language-javascript"
-          data-node-view-content=""
-          data-placeholder=""
-          style="white-space: pre-wrap;"
         />
       </pre>
     </div>

--- a/packages/legacy-editor/__snapshots__/components/blockViews/HeadingView/__tests__/HeadingView.test.tsx.snap
+++ b/packages/legacy-editor/__snapshots__/components/blockViews/HeadingView/__tests__/HeadingView.test.tsx.snap
@@ -7,11 +7,8 @@ exports[`HeadingView matches snapshot correctly 1`] = `
     style="white-space: normal; position: relative; pointer-events: unset;"
   >
     <h1
-      as="h1"
       class="mc-c-fHQyyx mc-c-fHQyyx-cOVgnz-level-1"
-      data-node-view-content=""
       data-placeholder="placeholder.heading1"
-      style="white-space: pre-wrap;"
     />
   </div>
 </div>
@@ -24,11 +21,8 @@ exports[`HeadingView renders correspond heading according to level level 2 1`] =
     style="white-space: normal; position: relative; pointer-events: unset;"
   >
     <h2
-      as="h2"
       class="mc-c-fHQyyx mc-c-fHQyyx-gPLAez-level-2"
-      data-node-view-content=""
       data-placeholder="placeholder.heading2"
-      style="white-space: pre-wrap;"
     />
   </div>
 </div>
@@ -41,11 +35,8 @@ exports[`HeadingView renders correspond heading according to level level 3 1`] =
     style="white-space: normal; position: relative; pointer-events: unset;"
   >
     <h3
-      as="h3"
       class="mc-c-fHQyyx mc-c-fHQyyx-llzMLw-level-3"
-      data-node-view-content=""
       data-placeholder="placeholder.heading3"
-      style="white-space: pre-wrap;"
     />
   </div>
 </div>
@@ -58,11 +49,8 @@ exports[`HeadingView renders correspond heading according to level level 4 1`] =
     style="white-space: normal; position: relative; pointer-events: unset;"
   >
     <h4
-      as="h4"
       class="mc-c-fHQyyx mc-c-fHQyyx-dWBeGD-level-4"
-      data-node-view-content=""
       data-placeholder="placeholder.heading4"
-      style="white-space: pre-wrap;"
     />
   </div>
 </div>
@@ -75,11 +63,8 @@ exports[`HeadingView renders correspond heading according to level level 5 1`] =
     style="white-space: normal; position: relative; pointer-events: unset;"
   >
     <h5
-      as="h5"
       class="mc-c-fHQyyx mc-c-fHQyyx-hCSGfy-level-5"
-      data-node-view-content=""
       data-placeholder="placeholder.heading5"
-      style="white-space: pre-wrap;"
     />
   </div>
 </div>

--- a/packages/legacy-editor/__snapshots__/components/blockViews/ListView/__tests__/ListView.test.tsx.snap
+++ b/packages/legacy-editor/__snapshots__/components/blockViews/ListView/__tests__/ListView.test.tsx.snap
@@ -3,14 +3,12 @@
 exports[`ListView renders as bullet list 1`] = `
 <div>
   <div
-    class="mc-c-czDAcb"
+    class="mc-c-bybahD"
     data-node-view-wrapper=""
     style="white-space: normal; pointer-events: unset;"
   >
     <ul
-      as="ul"
-      data-node-view-content=""
-      style="white-space: pre-wrap;"
+      data-list-view=""
     />
   </div>
 </div>
@@ -19,14 +17,12 @@ exports[`ListView renders as bullet list 1`] = `
 exports[`ListView renders as ordered list 1`] = `
 <div>
   <div
-    class="mc-c-dliBAz"
+    class="mc-c-fEhhnJ"
     data-node-view-wrapper=""
     style="white-space: normal; pointer-events: unset;"
   >
     <ol
-      as="ol"
-      data-node-view-content=""
-      style="white-space: pre-wrap;"
+      data-list-view=""
     />
   </div>
 </div>
@@ -35,15 +31,12 @@ exports[`ListView renders as ordered list 1`] = `
 exports[`ListView renders as task list 1`] = `
 <div>
   <div
-    class="mc-c-divPrt"
+    class="mc-c-dytFtL"
     data-node-view-wrapper=""
     style="white-space: normal; pointer-events: unset;"
   >
     <ul
-      as="ul"
-      data-node-view-content=""
-      data-task-list=""
-      style="white-space: pre-wrap;"
+      data-list-view=""
     />
   </div>
 </div>

--- a/packages/legacy-editor/__snapshots__/components/blockViews/ParagraphView/__tests__/ParagraphView.test.tsx.snap
+++ b/packages/legacy-editor/__snapshots__/components/blockViews/ParagraphView/__tests__/ParagraphView.test.tsx.snap
@@ -7,12 +7,9 @@ exports[`ParagraphView matches snapshot correctly 1`] = `
     style="white-space: normal; position: relative; pointer-events: unset;"
   >
     <p
-      as="p"
       class="mc-c-dfUVHB mc-c-qcqS"
-      data-node-view-content=""
       data-placeholder=""
       draggable="false"
-      style="white-space: pre-wrap;"
     />
   </div>
 </div>

--- a/packages/legacy-editor/__snapshots__/editors/documentEditor/__tests__/documentEditor.test.tsx.snap
+++ b/packages/legacy-editor/__snapshots__/editors/documentEditor/__tests__/documentEditor.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`documentEditor renders document editor correctly 1`] = `
         translate="no"
       >
         <div
-          class="react-renderer node-heading"
+          contenteditable="true"
         >
           <div
             data-node-view-wrapper=""
@@ -22,17 +22,11 @@ exports[`documentEditor renders document editor correctly 1`] = `
               class="mc-c-edKofp"
             >
               <h1
-                as="h1"
                 class="mc-c-fHQyyx mc-c-fHQyyx-cOVgnz-level-1"
-                data-node-view-content=""
                 data-placeholder=""
-                style="white-space: pre-wrap; --selection-padding: calc((2.875rem - 1.875rem) / 2); --bgColor-padding: calc((2.875rem - 1.875rem) / 2);"
+                style="--selection-padding: calc((2.875rem - 1.875rem) / 2); --bgColor-padding: calc((2.875rem - 1.875rem) / 2);"
               >
-                <div
-                  style="white-space: inherit;"
-                >
-                  heading1
-                </div>
+                heading1
               </h1>
               <div
                 aria-haspopup="dialog"
@@ -79,7 +73,7 @@ exports[`documentEditor renders document editor correctly 1`] = `
           </div>
         </div>
         <div
-          class="react-renderer node-heading"
+          contenteditable="true"
         >
           <div
             data-node-view-wrapper=""
@@ -89,17 +83,11 @@ exports[`documentEditor renders document editor correctly 1`] = `
               class="mc-c-edKofp"
             >
               <h2
-                as="h2"
                 class="mc-c-fHQyyx mc-c-fHQyyx-gPLAez-level-2"
-                data-node-view-content=""
                 data-placeholder=""
-                style="white-space: pre-wrap; --selection-padding: calc((2rem - 1.625rem) / 2); --bgColor-padding: calc((2rem - 1.625rem) / 2);"
+                style="--selection-padding: calc((2rem - 1.625rem) / 2); --bgColor-padding: calc((2rem - 1.625rem) / 2);"
               >
-                <div
-                  style="white-space: inherit;"
-                >
-                  heading2
-                </div>
+                heading2
               </h2>
               <div
                 aria-haspopup="dialog"
@@ -146,7 +134,7 @@ exports[`documentEditor renders document editor correctly 1`] = `
           </div>
         </div>
         <div
-          class="react-renderer node-heading"
+          contenteditable="true"
         >
           <div
             data-node-view-wrapper=""
@@ -156,17 +144,11 @@ exports[`documentEditor renders document editor correctly 1`] = `
               class="mc-c-edKofp"
             >
               <h3
-                as="h3"
                 class="mc-c-fHQyyx mc-c-fHQyyx-llzMLw-level-3"
-                data-node-view-content=""
                 data-placeholder=""
-                style="white-space: pre-wrap; --selection-padding: calc((1.875rem - 1.375rem) / 2); --bgColor-padding: calc((1.875rem - 1.375rem) / 2);"
+                style="--selection-padding: calc((1.875rem - 1.375rem) / 2); --bgColor-padding: calc((1.875rem - 1.375rem) / 2);"
               >
-                <div
-                  style="white-space: inherit;"
-                >
-                  heading3
-                </div>
+                heading3
               </h3>
               <div
                 aria-haspopup="dialog"
@@ -213,7 +195,7 @@ exports[`documentEditor renders document editor correctly 1`] = `
           </div>
         </div>
         <div
-          class="react-renderer node-heading"
+          contenteditable="true"
         >
           <div
             data-node-view-wrapper=""
@@ -223,17 +205,11 @@ exports[`documentEditor renders document editor correctly 1`] = `
               class="mc-c-edKofp"
             >
               <h4
-                as="h4"
                 class="mc-c-fHQyyx mc-c-fHQyyx-dWBeGD-level-4"
-                data-node-view-content=""
                 data-placeholder=""
-                style="white-space: pre-wrap; --selection-padding: calc((1.875rem - 1.25rem) / 2); --bgColor-padding: calc((1.875rem - 1.25rem) / 2);"
+                style="--selection-padding: calc((1.875rem - 1.25rem) / 2); --bgColor-padding: calc((1.875rem - 1.25rem) / 2);"
               >
-                <div
-                  style="white-space: inherit;"
-                >
-                  heading4
-                </div>
+                heading4
               </h4>
               <div
                 aria-haspopup="dialog"
@@ -280,7 +256,7 @@ exports[`documentEditor renders document editor correctly 1`] = `
           </div>
         </div>
         <div
-          class="react-renderer node-heading"
+          contenteditable="true"
         >
           <div
             data-node-view-wrapper=""
@@ -290,17 +266,11 @@ exports[`documentEditor renders document editor correctly 1`] = `
               class="mc-c-edKofp"
             >
               <h5
-                as="h5"
                 class="mc-c-fHQyyx mc-c-fHQyyx-hCSGfy-level-5"
-                data-node-view-content=""
                 data-placeholder=""
-                style="white-space: pre-wrap; --selection-padding: calc((1.5rem - 1rem) / 2); --bgColor-padding: calc((1.5rem - 1rem) / 2);"
+                style="--selection-padding: calc((1.5rem - 1rem) / 2); --bgColor-padding: calc((1.5rem - 1rem) / 2);"
               >
-                <div
-                  style="white-space: inherit;"
-                >
-                  heading5
-                </div>
+                heading5
               </h5>
               <div
                 aria-haspopup="dialog"

--- a/packages/legacy-editor/__snapshots__/extensions/blocks/bulletList/__tests__/bulletList.test.tsx.snap
+++ b/packages/legacy-editor/__snapshots__/extensions/blocks/bulletList/__tests__/bulletList.test.tsx.snap
@@ -10,37 +10,31 @@ exports[`BulletList renders BulletList correctly 1`] = `
       translate="no"
     >
       <div
-        class="react-renderer node-bulletList"
+        contenteditable="true"
       >
         <div
-          class="mc-c-czDAcb"
+          class="mc-c-bybahD"
           data-node-view-wrapper=""
           style="white-space: normal; pointer-events: unset;"
         >
           <ul
-            as="ul"
-            data-node-view-content=""
-            style="white-space: pre-wrap;"
+            data-list-view=""
           >
-            <div
-              style="white-space: inherit;"
-            >
-              <li>
-                <p>
-                  item 1
-                </p>
-              </li>
-              <li>
-                <p>
-                  item 2
-                </p>
-              </li>
-              <li>
-                <p>
-                  item 3
-                </p>
-              </li>
-            </div>
+            <li>
+              <p>
+                item 1
+              </p>
+            </li>
+            <li>
+              <p>
+                item 2
+              </p>
+            </li>
+            <li>
+              <p>
+                item 3
+              </p>
+            </li>
           </ul>
         </div>
       </div>

--- a/packages/legacy-editor/__snapshots__/extensions/blocks/callout/__tests__/callout.test.tsx.snap
+++ b/packages/legacy-editor/__snapshots__/extensions/blocks/callout/__tests__/callout.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Callout renders Callout correctly 1`] = `
       translate="no"
     >
       <div
-        class="react-renderer node-callout"
+        contenteditable="true"
       >
         <div
           data-node-view-wrapper=""
@@ -35,21 +35,14 @@ exports[`Callout renders Callout correctly 1`] = `
               </button>
             </div>
             <span
-              as="span"
               class="mc-c-hbPmqD"
-              data-node-view-content=""
               data-placeholder="placeholder.callout"
-              style="white-space: pre-wrap;"
             >
-              <div
-                style="white-space: inherit;"
-              >
-                <p>
-                  <br
-                    class="ProseMirror-trailingBreak"
-                  />
-                </p>
-              </div>
+              <p>
+                <br
+                  class="ProseMirror-trailingBreak"
+                />
+              </p>
             </span>
           </div>
         </div>

--- a/packages/legacy-editor/__snapshots__/extensions/blocks/codeBlock/__tests__/codeBlock.test.tsx.snap
+++ b/packages/legacy-editor/__snapshots__/extensions/blocks/codeBlock/__tests__/codeBlock.test.tsx.snap
@@ -10,10 +10,10 @@ exports[`CodeBlock renders CodeBlock correctly 1`] = `
       translate="no"
     >
       <div
-        class="react-renderer node-codeBlock"
+        contenteditable="true"
       >
         <div
-          class="mc-c-bxRahZ mc-c-eNvXfk"
+          class="mc-c-gSKecW mc-c-kMAtnc"
           data-node-view-wrapper=""
           style="white-space: normal; pointer-events: unset;"
         >
@@ -80,38 +80,31 @@ exports[`CodeBlock renders CodeBlock correctly 1`] = `
             </div>
             <pre
               class="line-numbers language-typescript"
+              data-placeholder=""
               spellcheck="false"
             >
               <code
-                as="code"
                 class="undefined language-typescript"
-                data-node-view-content=""
-                data-placeholder=""
-                style="white-space: pre-wrap;"
               >
                 <div
-                  style="white-space: inherit;"
-                >
-                  <div
-                    class="line-numbers-rows ProseMirror-widget"
-                  />
-                        
-
-                  <div
-                    class="line-numbers-rows ProseMirror-widget"
-                  />
-                          code content
-
-                  <div
-                    class="line-numbers-rows ProseMirror-widget"
-                  />
-                        
-
-                  <div
-                    class="line-numbers-rows ProseMirror-widget"
-                  />
+                  class="line-numbers-rows ProseMirror-widget"
+                />
                       
-                </div>
+
+                <div
+                  class="line-numbers-rows ProseMirror-widget"
+                />
+                        code content
+
+                <div
+                  class="line-numbers-rows ProseMirror-widget"
+                />
+                      
+
+                <div
+                  class="line-numbers-rows ProseMirror-widget"
+                />
+                    
               </code>
             </pre>
           </div>

--- a/packages/legacy-editor/__snapshots__/extensions/blocks/embed/__tests__/embed.test.tsx.snap
+++ b/packages/legacy-editor/__snapshots__/extensions/blocks/embed/__tests__/embed.test.tsx.snap
@@ -10,8 +10,7 @@ exports[`Embed renders Embed correctly 1`] = `
       translate="no"
     >
       <div
-        class="react-renderer node-embedBlock"
-        draggable="true"
+        contenteditable="false"
       >
         <div
           data-node-view-wrapper=""

--- a/packages/legacy-editor/__snapshots__/extensions/blocks/formula/__tests__/formula.test.tsx.snap
+++ b/packages/legacy-editor/__snapshots__/extensions/blocks/formula/__tests__/formula.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Formula renders Formula correctly 1`] = `
     >
       <p>
         <span
-          class="react-renderer node-formulaBlock"
+          contenteditable="false"
         >
           <span
             as="span"
@@ -64,10 +64,6 @@ exports[`Formula renders Formula correctly 1`] = `
             </span>
           </span>
         </span>
-        <img
-          alt=""
-          class="ProseMirror-separator"
-        />
         <br
           class="ProseMirror-trailingBreak"
         />

--- a/packages/legacy-editor/__snapshots__/extensions/blocks/heading/__tests__/heading.test.tsx.snap
+++ b/packages/legacy-editor/__snapshots__/extensions/blocks/heading/__tests__/heading.test.tsx.snap
@@ -10,112 +10,77 @@ exports[`Heading renders Heading correctly 1`] = `
       translate="no"
     >
       <div
-        class="react-renderer node-heading"
+        contenteditable="true"
       >
         <div
           data-node-view-wrapper=""
           style="white-space: normal; position: relative; pointer-events: unset;"
         >
           <h1
-            as="h1"
             class="mc-c-fHQyyx mc-c-fHQyyx-cOVgnz-level-1"
-            data-node-view-content=""
             data-placeholder=""
-            style="white-space: pre-wrap;"
           >
-            <div
-              style="white-space: inherit;"
-            >
-              h1
-            </div>
+            h1
           </h1>
         </div>
       </div>
       <div
-        class="react-renderer node-heading"
+        contenteditable="true"
       >
         <div
           data-node-view-wrapper=""
           style="white-space: normal; position: relative; pointer-events: unset;"
         >
           <h2
-            as="h2"
             class="mc-c-fHQyyx mc-c-fHQyyx-gPLAez-level-2"
-            data-node-view-content=""
             data-placeholder=""
-            style="white-space: pre-wrap;"
           >
-            <div
-              style="white-space: inherit;"
-            >
-              h2
-            </div>
+            h2
           </h2>
         </div>
       </div>
       <div
-        class="react-renderer node-heading"
+        contenteditable="true"
       >
         <div
           data-node-view-wrapper=""
           style="white-space: normal; position: relative; pointer-events: unset;"
         >
           <h3
-            as="h3"
             class="mc-c-fHQyyx mc-c-fHQyyx-llzMLw-level-3"
-            data-node-view-content=""
             data-placeholder=""
-            style="white-space: pre-wrap;"
           >
-            <div
-              style="white-space: inherit;"
-            >
-              h3
-            </div>
+            h3
           </h3>
         </div>
       </div>
       <div
-        class="react-renderer node-heading"
+        contenteditable="true"
       >
         <div
           data-node-view-wrapper=""
           style="white-space: normal; position: relative; pointer-events: unset;"
         >
           <h4
-            as="h4"
             class="mc-c-fHQyyx mc-c-fHQyyx-dWBeGD-level-4"
-            data-node-view-content=""
             data-placeholder=""
-            style="white-space: pre-wrap;"
           >
-            <div
-              style="white-space: inherit;"
-            >
-              h4
-            </div>
+            h4
           </h4>
         </div>
       </div>
       <div
-        class="react-renderer node-heading"
+        contenteditable="true"
       >
         <div
           data-node-view-wrapper=""
           style="white-space: normal; position: relative; pointer-events: unset;"
         >
           <h5
-            as="h5"
             class="mc-c-fHQyyx mc-c-fHQyyx-hCSGfy-level-5"
-            data-node-view-content=""
             data-placeholder=""
-            style="white-space: pre-wrap;"
           >
-            <div
-              style="white-space: inherit;"
-            >
-              h5
-            </div>
+            h5
           </h5>
         </div>
       </div>

--- a/packages/legacy-editor/__snapshots__/extensions/blocks/horizontalRule/__tests__/horizontalRule.test.tsx.snap
+++ b/packages/legacy-editor/__snapshots__/extensions/blocks/horizontalRule/__tests__/horizontalRule.test.tsx.snap
@@ -10,8 +10,7 @@ exports[`HorizontalRule renders HorizontalRule correctly 1`] = `
       translate="no"
     >
       <div
-        class="react-renderer node-horizontalRule"
-        draggable="true"
+        contenteditable="false"
       >
         <div
           data-node-view-wrapper=""

--- a/packages/legacy-editor/__snapshots__/extensions/blocks/orderedList/__tests__/orderedList.test.tsx.snap
+++ b/packages/legacy-editor/__snapshots__/extensions/blocks/orderedList/__tests__/orderedList.test.tsx.snap
@@ -10,37 +10,31 @@ exports[`OrderedList renders OrderedList correctly 1`] = `
       translate="no"
     >
       <div
-        class="react-renderer node-orderedList"
+        contenteditable="true"
       >
         <div
-          class="mc-c-dliBAz"
+          class="mc-c-fEhhnJ"
           data-node-view-wrapper=""
           style="white-space: normal; pointer-events: unset;"
         >
           <ol
-            as="ol"
-            data-node-view-content=""
-            style="white-space: pre-wrap;"
+            data-list-view=""
           >
-            <div
-              style="white-space: inherit;"
-            >
-              <li>
-                <p>
-                  item 1
-                </p>
-              </li>
-              <li>
-                <p>
-                  item 2
-                </p>
-              </li>
-              <li>
-                <p>
-                  item 3
-                </p>
-              </li>
-            </div>
+            <li>
+              <p>
+                item 1
+              </p>
+            </li>
+            <li>
+              <p>
+                item 2
+              </p>
+            </li>
+            <li>
+              <p>
+                item 3
+              </p>
+            </li>
           </ol>
         </div>
       </div>

--- a/packages/legacy-editor/__snapshots__/extensions/blocks/pageLink/__tests__/pageLink.test.tsx.snap
+++ b/packages/legacy-editor/__snapshots__/extensions/blocks/pageLink/__tests__/pageLink.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`PageLink renders PageLink correctly 1`] = `
     >
       <p>
         <span
-          class="react-renderer node-pageLinkBlock"
+          contenteditable="false"
         >
           <span
             as="span"
@@ -77,10 +77,6 @@ exports[`PageLink renders PageLink correctly 1`] = `
             </span>
           </span>
         </span>
-        <img
-          alt=""
-          class="ProseMirror-separator"
-        />
         <br
           class="ProseMirror-trailingBreak"
         />

--- a/packages/legacy-editor/__snapshots__/extensions/blocks/paragraph/__tests__/paragraph.test.tsx.snap
+++ b/packages/legacy-editor/__snapshots__/extensions/blocks/paragraph/__tests__/paragraph.test.tsx.snap
@@ -10,25 +10,18 @@ exports[`Paragraph renders Paragraph correctly 1`] = `
       translate="no"
     >
       <div
-        class="react-renderer node-paragraph"
+        contenteditable="true"
       >
         <div
           data-node-view-wrapper=""
           style="white-space: normal; position: relative; pointer-events: unset;"
         >
           <p
-            as="p"
             class="mc-c-dfUVHB mc-c-qcqS"
-            data-node-view-content=""
             data-placeholder=""
             draggable="false"
-            style="white-space: pre-wrap;"
           >
-            <div
-              style="white-space: inherit;"
-            >
-              paragraph
-            </div>
+            paragraph
           </p>
         </div>
       </div>

--- a/packages/legacy-editor/__snapshots__/extensions/blocks/taskList/__tests__/taskList.test.tsx.snap
+++ b/packages/legacy-editor/__snapshots__/extensions/blocks/taskList/__tests__/taskList.test.tsx.snap
@@ -10,54 +10,47 @@ exports[`TaskList renders TaskList correctly 1`] = `
       translate="no"
     >
       <div
-        class="react-renderer node-taskList"
+        contenteditable="true"
       >
         <div
-          class="mc-c-divPrt"
+          class="mc-c-dytFtL"
           data-node-view-wrapper=""
           style="white-space: normal; pointer-events: unset;"
         >
           <ul
-            as="ul"
-            data-node-view-content=""
-            data-task-list=""
-            style="white-space: pre-wrap;"
+            data-list-view=""
           >
-            <div
-              style="white-space: inherit;"
+            <li
+              data-checked="true"
             >
-              <li
-                data-checked="true"
-              >
-                <label>
-                  <input
-                    checked="checked"
-                    type="checkbox"
-                  />
-                  <span />
-                </label>
-                <div>
-                  <p>
-                    A list item
-                  </p>
-                </div>
-              </li>
-              <li
-                data-checked="false"
-              >
-                <label>
-                  <input
-                    type="checkbox"
-                  />
-                  <span />
-                </label>
-                <div>
-                  <p>
-                    And another one
-                  </p>
-                </div>
-              </li>
-            </div>
+              <label>
+                <input
+                  checked="checked"
+                  type="checkbox"
+                />
+                <span />
+              </label>
+              <div>
+                <p>
+                  A list item
+                </p>
+              </div>
+            </li>
+            <li
+              data-checked="false"
+            >
+              <label>
+                <input
+                  type="checkbox"
+                />
+                <span />
+              </label>
+              <div>
+                <p>
+                  And another one
+                </p>
+              </div>
+            </li>
           </ul>
         </div>
       </div>

--- a/packages/legacy-editor/__snapshots__/extensions/blocks/user/__tests__/user.test.tsx.snap
+++ b/packages/legacy-editor/__snapshots__/extensions/blocks/user/__tests__/user.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`User renders User correctly 1`] = `
     >
       <p>
         <span
-          class="react-renderer node-userBlock"
+          contenteditable="false"
         >
           <span
             as="span"
@@ -63,10 +63,6 @@ exports[`User renders User correctly 1`] = `
             </span>
           </span>
         </span>
-        <img
-          alt=""
-          class="ProseMirror-separator"
-        />
         <br
           class="ProseMirror-trailingBreak"
         />

--- a/packages/legacy-editor/src/components/blockViews/BlockquoteView/BlockquoteView.tsx
+++ b/packages/legacy-editor/src/components/blockViews/BlockquoteView/BlockquoteView.tsx
@@ -1,9 +1,10 @@
 import { FC } from 'react'
-import { NodeViewContent } from '../../../tiptapRefactor'
 import { BlockContainer } from '../BlockContainer'
 import { BlockViewProps } from '../../../extensions/common'
 import { useEditorI18n } from '../../../hooks'
 import { css, theme } from '@mashcard/design-system'
+import { useNodeContent } from '@mashcard/editor'
+import { BlockquoteAttributes, BlockquoteOptions } from '../../../extensions'
 
 const placeholderStyle = css({
   '&:before': {
@@ -19,11 +20,17 @@ const placeholderStyle = css({
   }
 })
 
-export const BlockquoteView: FC<BlockViewProps<{}, {}>> = ({ deleteNode, node, getPos }) => {
+export const BlockquoteView: FC<BlockViewProps<BlockquoteOptions, BlockquoteAttributes>> = ({
+  deleteNode,
+  node,
+  getPos
+}) => {
   const [t] = useEditorI18n()
   const isEmpty = node.textContent.length === 0
   const placeholder = isEmpty ? t(`placeholder.blockquote`) : ''
   const placeholderClassName = placeholderStyle()
+
+  const nodeContentRef = useNodeContent<HTMLQuoteElement>()
 
   return (
     <BlockContainer
@@ -31,9 +38,8 @@ export const BlockquoteView: FC<BlockViewProps<{}, {}>> = ({ deleteNode, node, g
       node={node}
       actionOptions={['cut', 'copy', 'delete']}
       deleteNode={deleteNode}
-      getPos={getPos}
-    >
-      <NodeViewContent as="blockquote" data-placeholder={placeholder} className={placeholderClassName} />
+      getPos={getPos}>
+      <blockquote ref={nodeContentRef} data-placeholder={placeholder} className={placeholderClassName} />
     </BlockContainer>
   )
 }

--- a/packages/legacy-editor/src/components/blockViews/BlockquoteView/__tests__/Blockquote.test.tsx
+++ b/packages/legacy-editor/src/components/blockViews/BlockquoteView/__tests__/Blockquote.test.tsx
@@ -1,10 +1,12 @@
 import { render } from '@testing-library/react'
+import { BlockquoteOptions } from '@tiptap/extension-blockquote'
+import { BlockquoteAttributes } from '../../../../extensions'
 import { mockBlockViewProps } from '../../../../test'
 import { BlockquoteView } from '../BlockquoteView'
 
 describe('BlockquoteView', () => {
   it(`renders blockquote correctly`, () => {
-    const props = mockBlockViewProps<{}, {}>({
+    const props = mockBlockViewProps<BlockquoteOptions, BlockquoteAttributes>({
       node: {
         textContent: 'text content'
       }

--- a/packages/legacy-editor/src/components/blockViews/CalloutView/CalloutView.tsx
+++ b/packages/legacy-editor/src/components/blockViews/CalloutView/CalloutView.tsx
@@ -1,10 +1,10 @@
 import { FC } from 'react'
-import { NodeViewContent } from '../../../tiptapRefactor'
 import { BlockContainer } from '../BlockContainer'
 import { CalloutViewProps } from '../../../extensions/blocks/callout/meta'
 import { css, styled, theme } from '@mashcard/design-system'
 import { iconWidth, useIcon } from './useIcon'
 import { useEditorI18n } from '../../../hooks'
+import { useNodeContent } from '@mashcard/editor'
 
 const verticalPadding = '1.5rem'
 const iconMarginRight = '0.75rem'
@@ -46,6 +46,7 @@ export const CalloutView: FC<CalloutViewProps> = ({ deleteNode, node, extension,
   const isEmpty = node.textContent.length === 0
   const placeholder = isEmpty ? t(`placeholder.callout`) : ''
   const placeholderClassName = placeholderStyle()
+  const nodeContentRef = useNodeContent()
 
   return (
     <BlockContainer
@@ -53,11 +54,10 @@ export const CalloutView: FC<CalloutViewProps> = ({ deleteNode, node, extension,
       node={node}
       actionOptions={['cut', 'copy', 'delete']}
       deleteNode={deleteNode}
-      getPos={getPos}
-    >
+      getPos={getPos}>
       <CalloutContainer>
         <IconContainer>{icon}</IconContainer>
-        <NodeViewContent as="span" className={placeholderClassName} data-placeholder={placeholder} />
+        <span ref={nodeContentRef} className={placeholderClassName} data-placeholder={placeholder} />
       </CalloutContainer>
     </BlockContainer>
   )

--- a/packages/legacy-editor/src/components/blockViews/CodeBlockView/CodeBlockView.tsx
+++ b/packages/legacy-editor/src/components/blockViews/CodeBlockView/CodeBlockView.tsx
@@ -1,7 +1,6 @@
 import { FC, useState } from 'react'
 import { LineDown, Check } from '@mashcard/design-icons'
 import { Menu, Input, Popover, Switch, styled, theme, cx } from '@mashcard/design-system'
-import { NodeViewContent } from '../../../tiptapRefactor'
 import { BlockContainer } from '../BlockContainer'
 import {
   highlightStyle,
@@ -16,6 +15,7 @@ import { CodeBlockAttributes } from '../../../extensions'
 import { languageNames } from '../../../extensions/blocks/codeBlock/refractorLanguagesBundle'
 import { useEditorI18n } from '../../../hooks'
 import { BlockActionOptions } from '../BlockActions'
+import { useNodeContent } from '@mashcard/editor'
 
 const LanguageChecked = styled(Check, {
   fontSize: '1rem',
@@ -79,8 +79,7 @@ const LanguageSelect: FC<ILanguageSelect> = (props: ILanguageSelect) => {
       compact={true}
       getPopupContainer={element => element}
       content={menu}
-      destroyTooltipOnHide={true}
-    >
+      destroyTooltipOnHide={true}>
       <div role="tab" tabIndex={0} onClick={updateVisible} onKeyDown={updateVisible}>
         {t(`code_block.languages.${language}`)} <LineDown />
       </div>
@@ -103,6 +102,7 @@ export const CodeBlockView: FC<CodeBlockViewProps> = ({ node, updateAttributes, 
   const [t] = useEditorI18n()
   const isEmpty = node.textContent.length === 0
   const placeholder = isEmpty ? t(`placeholder.code_block`) : ''
+  const nodeContentRef = useNodeContent()
 
   return (
     <BlockContainer
@@ -111,8 +111,7 @@ export const CodeBlockView: FC<CodeBlockViewProps> = ({ node, updateAttributes, 
       className={cx(highlightStyle(), placeholderStyle())}
       getPos={getPos}
       deleteNode={deleteNode}
-      actionOptions={actionOptions}
-    >
+      actionOptions={actionOptions}>
       <CodeContainer>
         <ViewModeBar>
           <LanguageSelect language={language ?? defaultLanguage} updateAttributes={updateAttributes} />
@@ -121,11 +120,13 @@ export const CodeBlockView: FC<CodeBlockViewProps> = ({ node, updateAttributes, 
             <Switch checked={!!autoWrap} size="sm" onChange={onAutoWrapChange} />
           </SwitchContainer>
         </ViewModeBar>
-        <pre className={`line-numbers language-${language ?? defaultLanguage}`} spellCheck={false}>
-          <NodeViewContent
+        <pre
+          className={`line-numbers language-${language ?? defaultLanguage}`}
+          spellCheck={false}
+          data-placeholder={placeholder}>
+          <code
+            ref={nodeContentRef}
             className={`${autoWrap ? undefined : CodeScroll()} language-${language ?? defaultLanguage}`}
-            as="code"
-            data-placeholder={placeholder}
           />
         </pre>
       </CodeContainer>

--- a/packages/legacy-editor/src/components/blockViews/CodeBlockView/styles/highlight.style.ts
+++ b/packages/legacy-editor/src/components/blockViews/CodeBlockView/styles/highlight.style.ts
@@ -39,15 +39,18 @@ export const SwitchContainer = styled('div', {
   }
 })
 
+const prePaddingLeft = '3rem'
+const prePaddingTop = '1rem'
+
 export const placeholderStyle = css({
-  code: {
+  pre: {
     '&:before': {
       color: theme.colors.typeThirdary,
       content: 'attr(data-placeholder)',
-      left: 0,
+      left: prePaddingLeft,
       pointerEvents: 'none',
       position: 'absolute',
-      top: 0,
+      top: prePaddingTop,
       whiteSpace: 'nowrap'
     }
   }
@@ -74,7 +77,7 @@ export const highlightStyle = css({
     },
   'pre[class*="language-"].line-numbers': {
     position: 'relative',
-    paddingLeft: '3rem',
+    paddingLeft: prePaddingLeft,
     counterReset: 'linenumber'
   },
   'pre[class*="language-"].line-numbers > code': {
@@ -107,6 +110,7 @@ export const highlightStyle = css({
   },
   'pre[class*="language-"]': {
     padding: '1em',
+    paddingTop: prePaddingTop,
     margin: '.5em 0',
     overflow: 'auto'
   },

--- a/packages/legacy-editor/src/components/blockViews/HeadingView/HeadingView.tsx
+++ b/packages/legacy-editor/src/components/blockViews/HeadingView/HeadingView.tsx
@@ -1,9 +1,9 @@
 import { FC, useMemo } from 'react'
-import { NodeViewContent } from '../../../tiptapRefactor'
 import { css, theme } from '@mashcard/design-system'
 import { BlockContainer } from '../BlockContainer'
 import { HeadingViewProps } from '../../../extensions/blocks/heading/meta'
 import { useEditorI18n } from '../../../hooks'
+import { useNodeContent } from '@mashcard/editor'
 
 const placeholderStyle = css({
   '&:before': {
@@ -103,7 +103,7 @@ const actionButtonStyle = css({
 })
 
 export const HeadingView: FC<HeadingViewProps> = ({ node, deleteNode, extension, getPos }) => {
-  const as = useMemo(() => {
+  const Tag = useMemo(() => {
     switch (Number(node.attrs.level)) {
       case 2:
         return 'h2'
@@ -123,6 +123,7 @@ export const HeadingView: FC<HeadingViewProps> = ({ node, deleteNode, extension,
   const actionButtonClassName = actionButtonStyle({ level: node.attrs.level })
   const placeholderClassName = placeholderStyle({ level: node.attrs.level })
   const [t] = useEditorI18n()
+  const nodeContentRef = useNodeContent()
   const isEmpty = !node.isLeaf && !node.childCount
   const placeholder = isEmpty ? t(`placeholder.heading${node.attrs.level}`) : ''
 
@@ -142,9 +143,8 @@ export const HeadingView: FC<HeadingViewProps> = ({ node, deleteNode, extension,
       }}
       getPos={getPos}
       deleteNode={deleteNode}
-      contentForCopy={node.textContent}
-    >
-      <NodeViewContent {...HTMLAttributes} as={as} className={placeholderClassName} data-placeholder={placeholder} />
+      contentForCopy={node.textContent}>
+      <Tag ref={nodeContentRef} {...HTMLAttributes} className={placeholderClassName} data-placeholder={placeholder} />
     </BlockContainer>
   )
 }

--- a/packages/legacy-editor/src/components/blockViews/ListView/ListView.style.ts
+++ b/packages/legacy-editor/src/components/blockViews/ListView/ListView.style.ts
@@ -2,7 +2,7 @@ import { css, CSS, theme } from '@mashcard/design-system'
 import checkedIcon from '@mashcard/design-icons/assets/basic/check.svg'
 
 export const listLevelStyles = {
-  'ul[data-node-view-content=""]': {
+  'ul[data-list-view=""]': {
     listStyleType: 'disc',
 
     ul: {
@@ -39,10 +39,10 @@ export const listItemStyles: CSS = {
 }
 
 export const bulletListStyles = css({
-  'ul[data-node-view-content=""]': {
+  'ul[data-list-view=""]': {
     margin: 0,
     padding: '0 0 0 1.5rem',
-    ...listLevelStyles['ul[data-node-view-content=""]'],
+    ...listLevelStyles['ul[data-list-view=""]'],
 
     li: {
       fontSize: '1rem',
@@ -66,7 +66,7 @@ export const bulletListStyles = css({
 })
 
 export const orderedListStyles = css({
-  'ol[data-node-view-content=""]': {
+  'ol[data-list-view=""]': {
     counterReset: 'item',
     listStyleType: 'none',
     padding: 0,
@@ -92,7 +92,7 @@ export const orderedListStyles = css({
 })
 
 export const taskListStyles = css({
-  'ul[data-node-view-content=""]': {
+  'ul[data-list-view=""]': {
     listStyleType: 'none',
     paddingLeft: 0,
 

--- a/packages/legacy-editor/src/components/blockViews/ListView/ListView.tsx
+++ b/packages/legacy-editor/src/components/blockViews/ListView/ListView.tsx
@@ -1,12 +1,12 @@
 import { FC } from 'react'
-import { NodeViewContent } from '../../../tiptapRefactor'
 import { BlockContainer } from '../BlockContainer'
 import { BlockViewProps } from '../../../extensions/common'
 import { BulletList, OrderedList, TaskList } from '../../../extensions'
 import { orderedListStyles, bulletListStyles, taskListStyles } from './ListView.style'
+import { useNodeContent } from '@mashcard/editor'
 
 export const ListView: FC<BlockViewProps<{}, {}>> = ({ deleteNode, node, getPos }) => {
-  const as = node.type.name === OrderedList.name ? 'ol' : 'ul'
+  const Tag = node.type.name === OrderedList.name ? 'ol' : 'ul'
 
   let className = ''
   if (node.type.name === OrderedList.name) {
@@ -17,6 +17,8 @@ export const ListView: FC<BlockViewProps<{}, {}>> = ({ deleteNode, node, getPos 
     className = taskListStyles()
   }
 
+  const nodeContentRef = useNodeContent<HTMLOListElement>()
+
   return (
     <BlockContainer
       editable="custom"
@@ -24,9 +26,8 @@ export const ListView: FC<BlockViewProps<{}, {}>> = ({ deleteNode, node, getPos 
       className={className}
       actionOptions={['cut', 'copy', 'delete']}
       deleteNode={deleteNode}
-      getPos={getPos}
-    >
-      <NodeViewContent as={as} data-task-list={TaskList.name === node.type.name ? '' : undefined} />
+      getPos={getPos}>
+      <Tag ref={nodeContentRef} data-list-view="" />
     </BlockContainer>
   )
 }

--- a/packages/legacy-editor/src/components/blockViews/ParagraphView/ParagraphView.tsx
+++ b/packages/legacy-editor/src/components/blockViews/ParagraphView/ParagraphView.tsx
@@ -1,9 +1,9 @@
 import { FC } from 'react'
-import { NodeViewContent } from '../../../tiptapRefactor'
 import { css, cx, theme } from '@mashcard/design-system'
 import { BlockContainer } from '../BlockContainer'
 import { ParagraphViewProps } from '../../../extensions/blocks/paragraph/meta'
 import { usePlaceholder } from './usePlaceholder'
+import { useNodeContent } from '@mashcard/editor'
 
 const placeholderStyle = css({
   '&:before': {
@@ -28,6 +28,7 @@ export const ParagraphView: FC<ParagraphViewProps> = props => {
   const placeholderClassName = placeholderStyle()
   const paragraphClassName = paragraphStyles()
   const placeholder = usePlaceholder(editor, node, getPos)
+  const nodeContentRef = useNodeContent<HTMLParagraphElement>()
 
   return (
     <BlockContainer
@@ -36,13 +37,12 @@ export const ParagraphView: FC<ParagraphViewProps> = props => {
       editable="custom"
       deleteNode={deleteNode}
       style={{ position: 'relative' }}
-      actionOptions={['cut', 'copy', 'delete', 'transform']}
-    >
-      <NodeViewContent
+      actionOptions={['cut', 'copy', 'delete', 'transform']}>
+      <p
+        ref={nodeContentRef}
         {...extension.options.HTMLAttributes}
         draggable={false}
         data-placeholder={placeholder}
-        as="p"
         className={cx(placeholderClassName, paragraphClassName)}
       />
     </BlockContainer>

--- a/packages/legacy-editor/src/extensions/blocks/embed/embed.ts
+++ b/packages/legacy-editor/src/extensions/blocks/embed/embed.ts
@@ -80,7 +80,7 @@ export const Embed = createBlock<EmbedOptions, EmbedAttributes>({
   },
 
   addNodeView() {
-    return ReactNodeViewRenderer(EmbedView)
+    return ReactNodeViewRenderer(EmbedView, { contentEditable: false })
   },
 
   addCommands() {

--- a/packages/legacy-editor/src/extensions/blocks/formula/formula.ts
+++ b/packages/legacy-editor/src/extensions/blocks/formula/formula.ts
@@ -54,7 +54,7 @@ export const Formula = createBlock<FormulaOptions, FormulaAttributes>({
   },
 
   addNodeView() {
-    return ReactNodeViewRenderer(FormulaBlock)
+    return ReactNodeViewRenderer(FormulaBlock, { as: 'span', contentEditable: false })
   },
 
   addCommands() {

--- a/packages/legacy-editor/src/extensions/blocks/horizontalRule/horizontalRule.ts
+++ b/packages/legacy-editor/src/extensions/blocks/horizontalRule/horizontalRule.ts
@@ -12,7 +12,7 @@ export const HorizontalRule = TiptapHorizontalRule.extend({
   draggable: true,
 
   addNodeView() {
-    return ReactNodeViewRenderer(HorizontalRuleView)
+    return ReactNodeViewRenderer(HorizontalRuleView, { contentEditable: false })
   },
 
   addCommands() {

--- a/packages/legacy-editor/src/extensions/blocks/pageLink/pageLink.ts
+++ b/packages/legacy-editor/src/extensions/blocks/pageLink/pageLink.ts
@@ -54,7 +54,7 @@ export const PageLink = createBlock<PageLinkOptions, PageLinkAttributes>({
   },
 
   addNodeView() {
-    return ReactNodeViewRenderer(PageLinkView)
+    return ReactNodeViewRenderer(PageLinkView, { as: 'span', contentEditable: false })
   },
 
   addCommands() {

--- a/packages/legacy-editor/src/extensions/blocks/spreadsheet/spreadsheet.ts
+++ b/packages/legacy-editor/src/extensions/blocks/spreadsheet/spreadsheet.ts
@@ -1,5 +1,5 @@
 import { mergeAttributes } from '@tiptap/core'
-import { ReactNodeViewRenderer } from '../../../tiptapRefactor'
+import { LegacyReactNodeViewRenderer } from '../../../tiptapRefactor'
 import { uuid } from '@mashcard/active-support'
 import { SpreadsheetBlockView } from '../../../components/blockViews'
 import { createBlock } from '../../common'
@@ -71,7 +71,7 @@ export const Spreadsheet = createBlock<SpreadsheetOptions, SpreadsheetAttributes
   },
 
   addNodeView() {
-    return ReactNodeViewRenderer(SpreadsheetBlockView)
+    return LegacyReactNodeViewRenderer(SpreadsheetBlockView)
   },
 
   addCommands() {

--- a/packages/legacy-editor/src/extensions/blocks/subPageMenu/subPageMenu.ts
+++ b/packages/legacy-editor/src/extensions/blocks/subPageMenu/subPageMenu.ts
@@ -1,5 +1,5 @@
 import { mergeAttributes } from '@tiptap/core'
-import { ReactNodeViewRenderer } from '../../../tiptapRefactor'
+import { LegacyReactNodeViewRenderer } from '../../../tiptapRefactor'
 import { SubPageMenuView } from '../../../components/blockViews'
 import { createBlock } from '../../common'
 import { meta, SubPageMenuAttributes, SubPageMenuOptions } from './meta'
@@ -39,7 +39,7 @@ export const SubPageMenu = createBlock<SubPageMenuOptions, SubPageMenuAttributes
   },
 
   addNodeView() {
-    return ReactNodeViewRenderer(SubPageMenuView)
+    return LegacyReactNodeViewRenderer(SubPageMenuView)
   },
 
   addCommands() {

--- a/packages/legacy-editor/src/extensions/blocks/toc/toc.ts
+++ b/packages/legacy-editor/src/extensions/blocks/toc/toc.ts
@@ -39,7 +39,7 @@ export const Toc = createBlock<TocOptions, TocAttributes>({
   },
 
   addNodeView() {
-    return ReactNodeViewRenderer(TocView)
+    return ReactNodeViewRenderer(TocView, { contentEditable: false })
   },
 
   addCommands() {

--- a/packages/legacy-editor/src/extensions/blocks/user/user.ts
+++ b/packages/legacy-editor/src/extensions/blocks/user/user.ts
@@ -49,7 +49,7 @@ export const User = createBlock<UserOptions, UserAttributes>({
   },
 
   addNodeView() {
-    return ReactNodeViewRenderer(UserView)
+    return ReactNodeViewRenderer(UserView, { as: 'span', contentEditable: false })
   },
 
   addCommands() {

--- a/packages/legacy-editor/src/tiptapRefactor/EditorContent.tsx
+++ b/packages/legacy-editor/src/tiptapRefactor/EditorContent.tsx
@@ -46,6 +46,9 @@ export const EditorContent: FC<EditorContentProps> = ({ editor, ...props }) => {
         }
       })
     }
+    ;(editor as ExtendEditor).removePortal = (id: string) => {
+      setNodePortals(nodePortals => nodePortals.filter(portal => portal.id !== id))
+    }
 
     setTimeout(() => {
       editor.createNodeViews()

--- a/packages/legacy-editor/src/tiptapRefactor/ReactNodeView.tsx
+++ b/packages/legacy-editor/src/tiptapRefactor/ReactNodeView.tsx
@@ -1,0 +1,353 @@
+import {
+  Decoration,
+  Node,
+  NodePortalStore,
+  NodeSelection,
+  ReactNodeView as EditorReactNodeView
+} from '@mashcard/editor'
+import { NodeViewRendererProps, NodeViewProps, Editor } from '@tiptap/core'
+import { ComponentType } from 'react'
+import { ReactNodeViewRendererOptions } from './ReactNodeViewRenderer'
+
+function isiOS(): boolean {
+  return (
+    ['iPad Simulator', 'iPhone Simulator', 'iPod Simulator', 'iPad', 'iPhone', 'iPod'].includes(navigator.platform) ||
+    // iPad on iOS 13 detection
+    (navigator.userAgent.includes('Mac') && 'ontouchend' in document)
+  )
+}
+
+export class ReactNodeView extends EditorReactNodeView<NodeViewProps> {
+  options: Partial<ReactNodeViewRendererOptions>
+  isDragging: boolean = false
+  selected: boolean = false
+
+  private componentProps: NodeViewProps
+
+  constructor(
+    editor: Editor,
+    props: NodeViewRendererProps,
+    options: Partial<ReactNodeViewRendererOptions>,
+    component: ComponentType<NodeViewProps>,
+    nodePortalStore: NodePortalStore
+  ) {
+    // Super call must be the first statement.
+    // So componentProps have to defined twice.
+    super({
+      component,
+      componentProps: {
+        editor,
+        extension: props.extension,
+        node: props.node,
+        decorations: props.decorations,
+        getPos: props.getPos as () => number,
+        selected: false,
+        updateAttributes(attributes: Record<string, any>): void {
+          const { editor, getPos, node } = props
+          editor.commands.command(({ tr }) => {
+            const pos = (getPos as () => number)()
+
+            tr.setNodeMarkup(pos, undefined, {
+              ...node.attrs,
+              ...attributes
+            })
+
+            return true
+          })
+        },
+        deleteNode(): void {
+          const { getPos, node, editor } = props
+
+          const from = (getPos as () => number)()
+          const to = from + node.nodeSize
+
+          editor.commands.deleteRange({ from, to })
+        }
+      },
+      editorView: editor.view,
+      nodePortalStore,
+      asContainer: options.as as keyof HTMLElementTagNameMap
+    })
+
+    this.container.setAttribute('contenteditable', String(options.contentEditable ?? true))
+
+    this.componentProps = {
+      editor,
+      extension: props.extension,
+      node: props.node,
+      decorations: props.decorations,
+      getPos: props.getPos as () => number,
+      selected: false,
+      updateAttributes: this.updateAttributes.bind(this),
+      deleteNode: this.deleteNode.bind(this)
+    }
+
+    this.options = {
+      stopEvent: null,
+      ignoreMutation: null,
+      ...options
+    }
+    ;(this.dom as HTMLElement).addEventListener('dragstart', this.onDragStart.bind(this))
+  }
+
+  private onDragStart(event: DragEvent): void {
+    const view = this.editorView
+    const target = event.target as HTMLElement
+
+    // get the drag handle element
+    // `closest` is not available for text nodes so we may have to use its parent
+    const dragHandle =
+      target.nodeType === 3 ? target.parentElement?.closest('[data-drag-handle]') : target.closest('[data-drag-handle]')
+
+    if (
+      !this.dom ||
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+      this.contentDOM?.contains(target) ||
+      !dragHandle
+    ) {
+      return
+    }
+
+    let x = 0
+    let y = 0
+
+    // calculate offset for drag element if we use a different drag handle element
+    if (this.dom !== dragHandle) {
+      const domBox = this.dom.getBoundingClientRect()
+      const handleBox = dragHandle.getBoundingClientRect()
+
+      const offsetX = event.offsetX
+      const offsetY = event.offsetY
+
+      x = handleBox.x - domBox.x + offsetX
+      y = handleBox.y - domBox.y + offsetY
+    }
+
+    event.dataTransfer?.setDragImage(this.dom, x, y)
+
+    // we need to tell ProseMirror that we want to move the whole node
+    // so we create a NodeSelection
+    const selection = NodeSelection.create(view.state.doc, this.componentProps.getPos())
+    const transaction = view.state.tr.setSelection(selection)
+
+    view.dispatch(transaction)
+  }
+
+  // fork from Tiptap NodeView
+  // eslint-disable-next-line complexity
+  public stopEvent(event: Event): boolean {
+    if (!this.dom) {
+      return false
+    }
+
+    if (typeof this.options.stopEvent === 'function') {
+      return this.options.stopEvent({ event })
+    }
+
+    const target = event.target as HTMLElement
+    const isInElement = this.dom.contains(target) && !this.contentDOM?.contains(target)
+
+    // any event from child nodes should be handled by ProseMirror
+    if (!isInElement) {
+      return false
+    }
+
+    const isDropEvent = event.type === 'drop'
+    const isInput = ['INPUT', 'BUTTON', 'SELECT', 'TEXTAREA'].includes(target.tagName) || target.isContentEditable
+
+    // any input event within node views should be ignored by ProseMirror
+    if (isInput && !isDropEvent) {
+      return true
+    }
+
+    const { isEditable } = this.componentProps.editor
+    const { isDragging } = this
+    const isDraggable = !!this.componentProps.node.type.spec.draggable
+    const isSelectable = NodeSelection.isSelectable(this.componentProps.node)
+    const isCopyEvent = event.type === 'copy'
+    const isPasteEvent = event.type === 'paste'
+    const isCutEvent = event.type === 'cut'
+    const isClickEvent = event.type === 'mousedown'
+    const isDragEvent = event.type.startsWith('drag')
+
+    // ProseMirror tries to drag selectable nodes
+    // even if `draggable` is set to `false`
+    // this fix prevents that
+    if (!isDraggable && isSelectable && isDragEvent) {
+      event.preventDefault()
+    }
+
+    if (isDraggable && isDragEvent && !isDragging) {
+      event.preventDefault()
+      return false
+    }
+
+    // we have to store that dragging started
+    if (isDraggable && isEditable && !isDragging && isClickEvent) {
+      const dragHandle = target.closest('[data-drag-handle]')
+      const isValidDragHandle = dragHandle && (this.dom === dragHandle || this.dom.contains(dragHandle))
+
+      if (isValidDragHandle) {
+        this.isDragging = true
+
+        document.addEventListener(
+          'dragend',
+          () => {
+            this.isDragging = false
+          },
+          { once: true }
+        )
+
+        document.addEventListener(
+          'mouseup',
+          () => {
+            this.isDragging = false
+          },
+          { once: true }
+        )
+      }
+    }
+
+    // these events are handled by prosemirror
+    if (isDragging || isDropEvent || isCopyEvent || isPasteEvent || isCutEvent || (isClickEvent && isSelectable)) {
+      return false
+    }
+
+    return true
+  }
+
+  public ignoreMutation(mutation: MutationRecord | { type: 'selection'; target: Element }): boolean {
+    if (!this.dom || !this.contentDOM) {
+      return true
+    }
+
+    if (typeof this.options.ignoreMutation === 'function') {
+      return this.options.ignoreMutation({ mutation })
+    }
+
+    // a leaf/atom node is like a black box for ProseMirror
+    // and should be fully handled by the node view
+    if (this.componentProps.node.isLeaf || this.componentProps.node.isAtom) {
+      return true
+    }
+
+    // ProseMirror should handle any selections
+    if (mutation.type === 'selection') {
+      return false
+    }
+
+    // try to prevent a bug on iOS that will break node views on enter
+    // this is because ProseMirror can’t preventDispatch on enter
+    // this will lead to a re-render of the node view on enter
+    // see: https://github.com/ueberdosis/tiptap/issues/1214
+    if (
+      this.dom.contains(mutation.target) &&
+      mutation.type === 'childList' &&
+      isiOS() &&
+      this.componentProps.editor.isFocused
+    ) {
+      const changedNodes = [...Array.from(mutation.addedNodes), ...Array.from(mutation.removedNodes)] as HTMLElement[]
+
+      // we’ll check if every changed node is contentEditable
+      // to make sure it’s probably mutated by ProseMirror
+      if (changedNodes.every(node => node.isContentEditable)) {
+        return false
+      }
+    }
+
+    // we will allow mutation contentDOM with attributes
+    // so we can for example adding classes within our node view
+    if (this.contentDOM === mutation.target && mutation.type === 'attributes') {
+      return true
+    }
+
+    // ProseMirror should handle any changes within contentDOM
+    if (this.contentDOM.contains(mutation.target)) {
+      return false
+    }
+
+    return true
+  }
+
+  public update(node: Node, decorations: Decoration[]): boolean {
+    const updateProps = (props?: Partial<NodeViewProps>): void => {
+      this.updateComponentProps(props)
+    }
+
+    if (node.type !== this.componentProps.node.type) {
+      return false
+    }
+
+    if (typeof this.options.update === 'function') {
+      const oldNode = this.componentProps.node
+      const oldDecorations = this.componentProps.decorations
+
+      this.componentProps.node = node
+      this.componentProps.decorations = decorations
+
+      return this.options.update({
+        oldNode,
+        oldDecorations,
+        newNode: node,
+        newDecorations: decorations,
+        updateProps: () => updateProps({ node, decorations })
+      })
+    }
+
+    if (node === this.componentProps.node && this.componentProps.decorations === decorations) {
+      return true
+    }
+
+    this.componentProps.node = node
+    this.componentProps.decorations = decorations
+
+    updateProps({ node, decorations })
+
+    return true
+  }
+
+  public selectNode(): void {
+    this.updateComponentProps({ selected: true })
+  }
+
+  public deselectNode(): void {
+    this.updateComponentProps({ selected: false })
+  }
+
+  public override destroy(): void {
+    this.nodePortalStore.remove(this.id)
+    this.contentDOM = null
+  }
+
+  private updateAttributes(attributes: Record<string, any>): void {
+    const { editor, getPos, node } = this.componentProps
+    editor.commands.command(({ tr }) => {
+      const pos = getPos()
+
+      tr.setNodeMarkup(pos, undefined, {
+        ...node.attrs,
+        ...attributes
+      })
+
+      return true
+    })
+  }
+
+  private deleteNode(): void {
+    const { getPos, node, editor } = this.componentProps
+
+    const from = getPos()
+    const to = from + node.nodeSize
+
+    editor.commands.deleteRange({ from, to })
+  }
+
+  private updateComponentProps(props?: Partial<NodeViewProps>): void {
+    this.componentProps = {
+      ...this.componentProps,
+      ...props
+    }
+
+    this.renderComponent(this.componentProps)
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3166,7 +3166,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@mashcard/editor@workspace:packages/editor"
   dependencies:
+    "@mashcard/active-support": "workspace:^"
     "@mashcard/dev-support": "workspace:^"
+    prosemirror-model: ^1.18.1
+    prosemirror-state: ^1.4.1
+    prosemirror-transform: ^1.6.0
+    prosemirror-view: ^1.27.0
   peerDependencies:
     react: ">=17.0.2"
     react-dom: ">=17.0.2"
@@ -18819,7 +18824,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prosemirror-model@npm:1.18.1, prosemirror-model@npm:^1.0.0, prosemirror-model@npm:^1.15.0, prosemirror-model@npm:^1.16.0":
+"prosemirror-model@npm:1.18.1, prosemirror-model@npm:^1.0.0, prosemirror-model@npm:^1.15.0, prosemirror-model@npm:^1.16.0, prosemirror-model@npm:^1.18.1":
   version: 1.18.1
   resolution: "prosemirror-model@npm:1.18.1"
   dependencies:
@@ -18839,7 +18844,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prosemirror-state@npm:1.4.1, prosemirror-state@npm:^1.0.0, prosemirror-state@npm:^1.2.2, prosemirror-state@npm:^1.3.4":
+"prosemirror-state@npm:1.4.1, prosemirror-state@npm:^1.0.0, prosemirror-state@npm:^1.2.2, prosemirror-state@npm:^1.3.4, prosemirror-state@npm:^1.4.1":
   version: 1.4.1
   resolution: "prosemirror-state@npm:1.4.1"
   dependencies:
@@ -18849,7 +18854,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prosemirror-transform@npm:1.6.0, prosemirror-transform@npm:^1.0.0, prosemirror-transform@npm:^1.1.0, prosemirror-transform@npm:^1.3.3":
+"prosemirror-transform@npm:1.6.0, prosemirror-transform@npm:^1.0.0, prosemirror-transform@npm:^1.1.0, prosemirror-transform@npm:^1.3.3, prosemirror-transform@npm:^1.6.0":
   version: 1.6.0
   resolution: "prosemirror-transform@npm:1.6.0"
   dependencies:


### PR DESCRIPTION
resolve #443 

1. creates a new react node view in `editor`.
2. makes Tiptap react renderer and react node view legacy in `legacy-editor`.
3. makes DOM construct simple for `NodeViewContent`.
4. keeps `SubpageMenu` using `LegacyReactNodeViewRenderer` because it will be a deprecated block soon.
5. keeps `SpreadsheetBlock` using `LegacyReactNodeViewRenderer` because of style is broken. @aligo please help me migrate it.
6. remains top-level container DOM, because it is necessary for [React SyntheticEvent](https://reactjs.org/docs/events.html)