### PR TITLE
fix(client): fix select highlight pos and add sub page loading problem

### DIFF
--- a/apps/client-web/src/routes/$domain/_shared/DocumentPageSidebar/PageTree/PageMenu.tsx
+++ b/apps/client-web/src/routes/$domain/_shared/DocumentPageSidebar/PageTree/PageMenu.tsx
@@ -298,8 +298,7 @@ export const PageMenu: React.FC<PageMenuProps> = ({
       visible={popoverVisible}
       onVisibleChange={onRenamePopoverVisibleChange}
       destroyTooltipOnHide={true}
-      overlayInnerStyle={{ marginLeft: icon ? -25 : 0 }}
-    >
+      overlayInnerStyle={{ marginLeft: icon ? -25 : 0 }}>
       <Root.Title to={linkPath}>{title}</Root.Title>
     </Popover>
   )
@@ -316,8 +315,7 @@ export const PageMenu: React.FC<PageMenuProps> = ({
         destoryPopupOnHide={true}
         visible={dropdownVisible}
         onVisibleChange={onDropdownVisibleChange}
-        placement="bottomStart"
-      >
+        placement="bottomStart">
         <Root.Menu>
           {linkData}
           <div>
@@ -329,13 +327,7 @@ export const PageMenu: React.FC<PageMenuProps> = ({
               </Dropdown>
             </Tooltip>
             <Tooltip title={t('blocks.create_sub_pages')}>
-              <Button
-                className="addBtn"
-                type="text"
-                onClick={onPressAddSubPage}
-                loading={createBlockLoading}
-                disabled={createBlockLoading}
-              >
+              <Button className="addBtn" type="text" onClick={onPressAddSubPage} disabled={createBlockLoading}>
                 <Icon.Add />
               </Button>
             </Tooltip>

--- a/packages/design-system/src/components/Select/index.tsx
+++ b/packages/design-system/src/components/Select/index.tsx
@@ -11,7 +11,7 @@ export interface SelectProps<ValueType = any, OptionType extends BaseOptionType 
 }
 
 const Select: ForwardRefRenderFunction<BaseSelectRef, SelectProps> = (props, ref) => {
-  const { virtual = true, borderless = false, getPopupContainer, className, ...otherProps } = props
+  const { virtual = false, borderless = false, getPopupContainer, className, ...otherProps } = props
   const prefixCls = props.prefixCls ?? selectStyle()
   return (
     <RcSelect


### PR DESCRIPTION
https://github.com/mashcard/mashcard/issues/460
https://github.com/mashcard/mashcard/issues/491

Disable the virtual mode of the **Select**  by default
**Select** has a cursor because it supports search

