### PR TITLE
fix(editor): hides cut/copy actions in Firefox

### DIFF
--- a/packages/dev-support/jest/dom.js
+++ b/packages/dev-support/jest/dom.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line max-classes-per-file
 require('@testing-library/jest-dom/extend-expect')
 const crypto = require('crypto')
 const { toHaveNoViolations } = require('jest-axe')
@@ -30,6 +31,10 @@ class ResizeObserver {
   disconnect() {}
 }
 window.ResizeObserver = ResizeObserver
+
+class ClipboardItem {}
+
+window.ClipboardItem = ClipboardItem
 
 Object.assign(navigator, {
   clipboard: {

--- a/packages/legacy-editor/src/components/blockViews/BlockActions/useBasicActionOptions.tsx
+++ b/packages/legacy-editor/src/components/blockViews/BlockActions/useBasicActionOptions.tsx
@@ -33,6 +33,8 @@ export interface UseActionOptionsProps {
   types: BasicActionOptionType[]
 }
 
+const isClipboardWriteable = (): boolean => !!ClipboardItem
+
 export function useBasicActionOptions({ types }: UseActionOptionsProps): ActionGroupOption | null {
   const [t] = useEditorI18n()
   const { deleteBlock, getPosition, contentForCopy, node } = useBlockContext()
@@ -90,7 +92,7 @@ export function useBasicActionOptions({ types }: UseActionOptionsProps): ActionG
       return null
     }
 
-    if (types.includes('cut')) {
+    if (isClipboardWriteable() && types.includes('cut')) {
       group.items.push({
         label: t('block_actions.basic.cut'),
         name: 'cut',
@@ -103,7 +105,7 @@ export function useBasicActionOptions({ types }: UseActionOptionsProps): ActionG
       })
     }
 
-    if (types.includes('copy')) {
+    if (isClipboardWriteable() && types.includes('copy')) {
       group.items.push({
         name: 'copy',
         label: t('block_actions.basic.copy'),


### PR DESCRIPTION
fix #232